### PR TITLE
Add additional requirements for running on MacOS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ openai
 guidance
 label-studio-sdk @ git+https://github.com/HumanSignal/label-studio-sdk.git@pd-support
 rich~=13.6
+pydantic
+redis-om


### PR DESCRIPTION
On startup, adala installs redis-om, which leads to some issues with pydantic. Pre-install these dependencies to prevent a crash-on-load error.