### PR TITLE
Updating badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![PyPI version](https://badge.fury.io/py/adala.svg)](https://badge.fury.io/py/adala)
-![Python Version](https://img.shields.io/badge/3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue)
+![Python Version](https://img.shields.io/badge/supported_python_version_-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue)
 ![GitHub](https://img.shields.io/github/license/HumanSignal/Adala)
 ![GitHub Repo stars](https://img.shields.io/github/stars/HumanSignal/Adala)
 [![](https://img.shields.io/discord/1166330284300570624?label=Discord&logo=discord)](https://discord.gg/QBtgTbXTgU)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![PyPI version](https://badge.fury.io/py/adala-pk-test.svg)](https://badge.fury.io/py/adala-pk-test)
+[![PyPI version](https://badge.fury.io/py/adala.svg)](https://badge.fury.io/py/adala)
+![Python Version](https://img.shields.io/badge/3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue)
 ![GitHub](https://img.shields.io/github/license/HumanSignal/Adala)
 ![GitHub Repo stars](https://img.shields.io/github/stars/HumanSignal/Adala)
 [![](https://img.shields.io/discord/1166330284300570624?label=Discord&logo=discord)](https://discord.gg/QBtgTbXTgU)


### PR DESCRIPTION
- Pipy badge points to official adala
- Badges for supported python version

<img width="929" alt="Screenshot 2023-10-25 at 13 18 06" src="https://github.com/HumanSignal/Adala/assets/5721767/1695006b-fd98-409d-a949-12471b5503cb">
