### PR TITLE
feat: DIA-953: Stream results from adala inference server into LSE

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -19,13 +19,13 @@ COPY pyproject.toml poetry.lock ./
 
 # Install dependencies
 RUN poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi --no-root
+    && poetry install --no-interaction --no-ansi --no-root --with label-studio
 
 COPY . .
 
 # Install adala and the app
 RUN poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi
+    && poetry install --no-interaction --no-ansi --with label-studio
 
 # Set the working directory in the container to where the app will be run from
 WORKDIR /usr/src/app/server

--- a/adala/environments/kafka.py
+++ b/adala/environments/kafka.py
@@ -54,13 +54,14 @@ class AsyncKafkaEnvironment(AsyncEnvironment):
     async def save(self):
         raise NotImplementedError("Save is not supported in Kafka environment")
 
-    async def message_receiver(self, consumer: AIOKafkaConsumer, timeout: int = 30):
+    async def message_receiver(self, consumer: AIOKafkaConsumer, timeout: int = 3):
         await consumer.start()
         try:
             while True:
                 try:
                     # Wait for the next message with a timeout
                     msg = await asyncio.wait_for(consumer.getone(), timeout=timeout)
+                    print_text(f"Received message: {msg.value}")
                     yield msg.value
                 except asyncio.TimeoutError:
                     print_text(
@@ -77,8 +78,10 @@ class AsyncKafkaEnvironment(AsyncEnvironment):
         try:
             for record in data:
                 await producer.send_and_wait(topic, value=record)
+                print_text(f"Sent message: {record} to {topic=}")
         finally:
             await producer.stop()
+            print_text(f"No more messages for {topic=}")
 
     async def get_next_batch(self, data_iterator, batch_size: int) -> List[Dict]:
         batch = []

--- a/adala/environments/kafka.py
+++ b/adala/environments/kafka.py
@@ -32,7 +32,29 @@ class AsyncKafkaEnvironment(AsyncEnvironment):
     kafka_input_topic: str
     kafka_output_topic: str
 
-    async def message_receiver(self, consumer: AIOKafkaConsumer, timeout: int = 3):
+    async def initialize(self):
+        # claim kafka topic from shared pool here?
+        pass
+
+    async def finalize(self):
+        # release kafka topic to shared pool here?
+        pass
+
+    async def get_feedback(
+        self,
+        skills: SkillSet,
+        predictions: InternalDataFrame,
+        num_feedbacks: Optional[int] = None,
+    ) -> EnvironmentFeedback:
+        raise NotImplementedError("Feedback is not supported in Kafka environment")
+
+    async def restore(self):
+        raise NotImplementedError("Restore is not supported in Kafka environment")
+
+    async def save(self):
+        raise NotImplementedError("Save is not supported in Kafka environment")
+
+    async def message_receiver(self, consumer: AIOKafkaConsumer, timeout: int = 30):
         await consumer.start()
         try:
             while True:

--- a/adala/environments/kafka.py
+++ b/adala/environments/kafka.py
@@ -61,12 +61,12 @@ class AsyncKafkaEnvironment(AsyncEnvironment):
                 try:
                     # Wait for the next message with a timeout
                     msg = await asyncio.wait_for(consumer.getone(), timeout=timeout)
-                    print_text(f"Received message: {msg.value}")
+                    # print_text(f"Received message: {msg.value}")
                     yield msg.value
                 except asyncio.TimeoutError:
-                    print_text(
-                        f"No message received within the timeout {timeout} seconds"
-                    )
+                    # print_text(
+                        # f"No message received within the timeout {timeout} seconds"
+                    # )
                     break
         finally:
             await consumer.stop()
@@ -78,10 +78,10 @@ class AsyncKafkaEnvironment(AsyncEnvironment):
         try:
             for record in data:
                 await producer.send_and_wait(topic, value=record)
-                print_text(f"Sent message: {record} to {topic=}")
+                # print_text(f"Sent message: {record} to {topic=}")
         finally:
             await producer.stop()
-            print_text(f"No more messages for {topic=}")
+            # print_text(f"No more messages for {topic=}")
 
     async def get_next_batch(self, data_iterator, batch_size: int) -> List[Dict]:
         batch = []

--- a/adala/environments/kafka.py
+++ b/adala/environments/kafka.py
@@ -65,7 +65,7 @@ class AsyncKafkaEnvironment(AsyncEnvironment):
                     yield msg.value
                 except asyncio.TimeoutError:
                     # print_text(
-                        # f"No message received within the timeout {timeout} seconds"
+                    # f"No message received within the timeout {timeout} seconds"
                     # )
                     break
         finally:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 # docker-compose.yml
-version: "3.8"
 services:
   kafka:
     restart: always

--- a/poetry.lock
+++ b/poetry.lock
@@ -7182,4 +7182,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.8,<3.12"
-content-hash = "4711d6697cab31689989b7c67ca5947379beec05f79725d2bbc9c02df8114661"
+content-hash = "7aa102b5a506839d14f2ef332680b99e659a02fbc50c05e6b10e6b0d12b57e1f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -226,6 +226,17 @@ test = ["anyio[trio]", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=
 trio = ["trio (<0.22)"]
 
 [[package]]
+name = "appdirs"
+version = "1.4.4"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+optional = false
+python-versions = "*"
+files = [
+    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
+    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
+
+[[package]]
 name = "appnope"
 version = "0.1.4"
 description = "Disable App Nap on macOS >= 10.9"
@@ -2998,6 +3009,209 @@ websocket-client = ">=0.32.0,<0.40.0 || >0.40.0,<0.41.dev0 || >=0.43.dev0"
 
 [package.extras]
 adal = ["adal (>=1.0.2)"]
+
+[[package]]
+name = "label-studio-sdk"
+version = "0.0.32"
+description = "Label Studio annotation tool"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "label-studio-sdk-0.0.32.tar.gz", hash = "sha256:83ba94157f3849748f1c7b9d56a8f708db3c3f8dc124af4c9e7abf1eddc295c2"},
+    {file = "label_studio_sdk-0.0.32-py3-none-any.whl", hash = "sha256:d624b7d6aab36918f4b46ef294ac8bd93d76be5c2b9556981fc9244f02effbbd"},
+]
+
+[package.dependencies]
+label-studio-tools = ">=0.0.1"
+lxml = ">=4.2.5"
+pydantic = ">1.7,<3"
+requests = ">=2.22.0,<3"
+
+[[package]]
+name = "label-studio-tools"
+version = "0.0.3"
+description = "Label studio common tools"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "label-studio-tools-0.0.3.tar.gz", hash = "sha256:2e31698f76293e0b5d83efa2b9bde60e6e6f0e96e58da482b1fc062a1bbfe4b6"},
+    {file = "label_studio_tools-0.0.3-py3-none-any.whl", hash = "sha256:72930ec95b2f203014b3741818cb46800dafdebf0247f1bd66bb14cc48a12e89"},
+]
+
+[package.dependencies]
+appdirs = ">=1.4.3"
+lxml = ">=4.2.5"
+
+[[package]]
+name = "lxml"
+version = "5.2.1"
+description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "lxml-5.2.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1f7785f4f789fdb522729ae465adcaa099e2a3441519df750ebdccc481d961a1"},
+    {file = "lxml-5.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6cc6ee342fb7fa2471bd9b6d6fdfc78925a697bf5c2bcd0a302e98b0d35bfad3"},
+    {file = "lxml-5.2.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:794f04eec78f1d0e35d9e0c36cbbb22e42d370dda1609fb03bcd7aeb458c6377"},
+    {file = "lxml-5.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c817d420c60a5183953c783b0547d9eb43b7b344a2c46f69513d5952a78cddf3"},
+    {file = "lxml-5.2.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2213afee476546a7f37c7a9b4ad4d74b1e112a6fafffc9185d6d21f043128c81"},
+    {file = "lxml-5.2.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b070bbe8d3f0f6147689bed981d19bbb33070225373338df755a46893528104a"},
+    {file = "lxml-5.2.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e02c5175f63effbd7c5e590399c118d5db6183bbfe8e0d118bdb5c2d1b48d937"},
+    {file = "lxml-5.2.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:3dc773b2861b37b41a6136e0b72a1a44689a9c4c101e0cddb6b854016acc0aa8"},
+    {file = "lxml-5.2.1-cp310-cp310-manylinux_2_28_ppc64le.whl", hash = "sha256:d7520db34088c96cc0e0a3ad51a4fd5b401f279ee112aa2b7f8f976d8582606d"},
+    {file = "lxml-5.2.1-cp310-cp310-manylinux_2_28_s390x.whl", hash = "sha256:bcbf4af004f98793a95355980764b3d80d47117678118a44a80b721c9913436a"},
+    {file = "lxml-5.2.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a2b44bec7adf3e9305ce6cbfa47a4395667e744097faed97abb4728748ba7d47"},
+    {file = "lxml-5.2.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:1c5bb205e9212d0ebddf946bc07e73fa245c864a5f90f341d11ce7b0b854475d"},
+    {file = "lxml-5.2.1-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:2c9d147f754b1b0e723e6afb7ba1566ecb162fe4ea657f53d2139bbf894d050a"},
+    {file = "lxml-5.2.1-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:3545039fa4779be2df51d6395e91a810f57122290864918b172d5dc7ca5bb433"},
+    {file = "lxml-5.2.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a91481dbcddf1736c98a80b122afa0f7296eeb80b72344d7f45dc9f781551f56"},
+    {file = "lxml-5.2.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2ddfe41ddc81f29a4c44c8ce239eda5ade4e7fc305fb7311759dd6229a080052"},
+    {file = "lxml-5.2.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:a7baf9ffc238e4bf401299f50e971a45bfcc10a785522541a6e3179c83eabf0a"},
+    {file = "lxml-5.2.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:31e9a882013c2f6bd2f2c974241bf4ba68c85eba943648ce88936d23209a2e01"},
+    {file = "lxml-5.2.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0a15438253b34e6362b2dc41475e7f80de76320f335e70c5528b7148cac253a1"},
+    {file = "lxml-5.2.1-cp310-cp310-win32.whl", hash = "sha256:6992030d43b916407c9aa52e9673612ff39a575523c5f4cf72cdef75365709a5"},
+    {file = "lxml-5.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:da052e7962ea2d5e5ef5bc0355d55007407087392cf465b7ad84ce5f3e25fe0f"},
+    {file = "lxml-5.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:70ac664a48aa64e5e635ae5566f5227f2ab7f66a3990d67566d9907edcbbf867"},
+    {file = "lxml-5.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1ae67b4e737cddc96c99461d2f75d218bdf7a0c3d3ad5604d1f5e7464a2f9ffe"},
+    {file = "lxml-5.2.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f18a5a84e16886898e51ab4b1d43acb3083c39b14c8caeb3589aabff0ee0b270"},
+    {file = "lxml-5.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c6f2c8372b98208ce609c9e1d707f6918cc118fea4e2c754c9f0812c04ca116d"},
+    {file = "lxml-5.2.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:394ed3924d7a01b5bd9a0d9d946136e1c2f7b3dc337196d99e61740ed4bc6fe1"},
+    {file = "lxml-5.2.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5d077bc40a1fe984e1a9931e801e42959a1e6598edc8a3223b061d30fbd26bbc"},
+    {file = "lxml-5.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:764b521b75701f60683500d8621841bec41a65eb739b8466000c6fdbc256c240"},
+    {file = "lxml-5.2.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:3a6b45da02336895da82b9d472cd274b22dc27a5cea1d4b793874eead23dd14f"},
+    {file = "lxml-5.2.1-cp311-cp311-manylinux_2_28_ppc64le.whl", hash = "sha256:5ea7b6766ac2dfe4bcac8b8595107665a18ef01f8c8343f00710b85096d1b53a"},
+    {file = "lxml-5.2.1-cp311-cp311-manylinux_2_28_s390x.whl", hash = "sha256:e196a4ff48310ba62e53a8e0f97ca2bca83cdd2fe2934d8b5cb0df0a841b193a"},
+    {file = "lxml-5.2.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:200e63525948e325d6a13a76ba2911f927ad399ef64f57898cf7c74e69b71095"},
+    {file = "lxml-5.2.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:dae0ed02f6b075426accbf6b2863c3d0a7eacc1b41fb40f2251d931e50188dad"},
+    {file = "lxml-5.2.1-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:ab31a88a651039a07a3ae327d68ebdd8bc589b16938c09ef3f32a4b809dc96ef"},
+    {file = "lxml-5.2.1-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:df2e6f546c4df14bc81f9498bbc007fbb87669f1bb707c6138878c46b06f6510"},
+    {file = "lxml-5.2.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5dd1537e7cc06efd81371f5d1a992bd5ab156b2b4f88834ca852de4a8ea523fa"},
+    {file = "lxml-5.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9b9ec9c9978b708d488bec36b9e4c94d88fd12ccac3e62134a9d17ddba910ea9"},
+    {file = "lxml-5.2.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:8e77c69d5892cb5ba71703c4057091e31ccf534bd7f129307a4d084d90d014b8"},
+    {file = "lxml-5.2.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:a8d5c70e04aac1eda5c829a26d1f75c6e5286c74743133d9f742cda8e53b9c2f"},
+    {file = "lxml-5.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c94e75445b00319c1fad60f3c98b09cd63fe1134a8a953dcd48989ef42318534"},
+    {file = "lxml-5.2.1-cp311-cp311-win32.whl", hash = "sha256:4951e4f7a5680a2db62f7f4ab2f84617674d36d2d76a729b9a8be4b59b3659be"},
+    {file = "lxml-5.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:5c670c0406bdc845b474b680b9a5456c561c65cf366f8db5a60154088c92d102"},
+    {file = "lxml-5.2.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:abc25c3cab9ec7fcd299b9bcb3b8d4a1231877e425c650fa1c7576c5107ab851"},
+    {file = "lxml-5.2.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:6935bbf153f9a965f1e07c2649c0849d29832487c52bb4a5c5066031d8b44fd5"},
+    {file = "lxml-5.2.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d793bebb202a6000390a5390078e945bbb49855c29c7e4d56a85901326c3b5d9"},
+    {file = "lxml-5.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd5562927cdef7c4f5550374acbc117fd4ecc05b5007bdfa57cc5355864e0a4"},
+    {file = "lxml-5.2.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0e7259016bc4345a31af861fdce942b77c99049d6c2107ca07dc2bba2435c1d9"},
+    {file = "lxml-5.2.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:530e7c04f72002d2f334d5257c8a51bf409db0316feee7c87e4385043be136af"},
+    {file = "lxml-5.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59689a75ba8d7ffca577aefd017d08d659d86ad4585ccc73e43edbfc7476781a"},
+    {file = "lxml-5.2.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f9737bf36262046213a28e789cc82d82c6ef19c85a0cf05e75c670a33342ac2c"},
+    {file = "lxml-5.2.1-cp312-cp312-manylinux_2_28_ppc64le.whl", hash = "sha256:3a74c4f27167cb95c1d4af1c0b59e88b7f3e0182138db2501c353555f7ec57f4"},
+    {file = "lxml-5.2.1-cp312-cp312-manylinux_2_28_s390x.whl", hash = "sha256:68a2610dbe138fa8c5826b3f6d98a7cfc29707b850ddcc3e21910a6fe51f6ca0"},
+    {file = "lxml-5.2.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:f0a1bc63a465b6d72569a9bba9f2ef0334c4e03958e043da1920299100bc7c08"},
+    {file = "lxml-5.2.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c2d35a1d047efd68027817b32ab1586c1169e60ca02c65d428ae815b593e65d4"},
+    {file = "lxml-5.2.1-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:79bd05260359170f78b181b59ce871673ed01ba048deef4bf49a36ab3e72e80b"},
+    {file = "lxml-5.2.1-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:865bad62df277c04beed9478fe665b9ef63eb28fe026d5dedcb89b537d2e2ea6"},
+    {file = "lxml-5.2.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:44f6c7caff88d988db017b9b0e4ab04934f11e3e72d478031efc7edcac6c622f"},
+    {file = "lxml-5.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:71e97313406ccf55d32cc98a533ee05c61e15d11b99215b237346171c179c0b0"},
+    {file = "lxml-5.2.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:057cdc6b86ab732cf361f8b4d8af87cf195a1f6dc5b0ff3de2dced242c2015e0"},
+    {file = "lxml-5.2.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:f3bbbc998d42f8e561f347e798b85513ba4da324c2b3f9b7969e9c45b10f6169"},
+    {file = "lxml-5.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:491755202eb21a5e350dae00c6d9a17247769c64dcf62d8c788b5c135e179dc4"},
+    {file = "lxml-5.2.1-cp312-cp312-win32.whl", hash = "sha256:8de8f9d6caa7f25b204fc861718815d41cbcf27ee8f028c89c882a0cf4ae4134"},
+    {file = "lxml-5.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:f2a9efc53d5b714b8df2b4b3e992accf8ce5bbdfe544d74d5c6766c9e1146a3a"},
+    {file = "lxml-5.2.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:70a9768e1b9d79edca17890175ba915654ee1725975d69ab64813dd785a2bd5c"},
+    {file = "lxml-5.2.1-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c38d7b9a690b090de999835f0443d8aa93ce5f2064035dfc48f27f02b4afc3d0"},
+    {file = "lxml-5.2.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5670fb70a828663cc37552a2a85bf2ac38475572b0e9b91283dc09efb52c41d1"},
+    {file = "lxml-5.2.1-cp36-cp36m-manylinux_2_28_x86_64.whl", hash = "sha256:958244ad566c3ffc385f47dddde4145088a0ab893504b54b52c041987a8c1863"},
+    {file = "lxml-5.2.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b6241d4eee5f89453307c2f2bfa03b50362052ca0af1efecf9fef9a41a22bb4f"},
+    {file = "lxml-5.2.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:2a66bf12fbd4666dd023b6f51223aed3d9f3b40fef06ce404cb75bafd3d89536"},
+    {file = "lxml-5.2.1-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:9123716666e25b7b71c4e1789ec829ed18663152008b58544d95b008ed9e21e9"},
+    {file = "lxml-5.2.1-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:0c3f67e2aeda739d1cc0b1102c9a9129f7dc83901226cc24dd72ba275ced4218"},
+    {file = "lxml-5.2.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:5d5792e9b3fb8d16a19f46aa8208987cfeafe082363ee2745ea8b643d9cc5b45"},
+    {file = "lxml-5.2.1-cp36-cp36m-musllinux_1_2_aarch64.whl", hash = "sha256:88e22fc0a6684337d25c994381ed8a1580a6f5ebebd5ad41f89f663ff4ec2885"},
+    {file = "lxml-5.2.1-cp36-cp36m-musllinux_1_2_ppc64le.whl", hash = "sha256:21c2e6b09565ba5b45ae161b438e033a86ad1736b8c838c766146eff8ceffff9"},
+    {file = "lxml-5.2.1-cp36-cp36m-musllinux_1_2_s390x.whl", hash = "sha256:afbbdb120d1e78d2ba8064a68058001b871154cc57787031b645c9142b937a62"},
+    {file = "lxml-5.2.1-cp36-cp36m-musllinux_1_2_x86_64.whl", hash = "sha256:627402ad8dea044dde2eccde4370560a2b750ef894c9578e1d4f8ffd54000461"},
+    {file = "lxml-5.2.1-cp36-cp36m-win32.whl", hash = "sha256:e89580a581bf478d8dcb97d9cd011d567768e8bc4095f8557b21c4d4c5fea7d0"},
+    {file = "lxml-5.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:59565f10607c244bc4c05c0c5fa0c190c990996e0c719d05deec7030c2aa8289"},
+    {file = "lxml-5.2.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:857500f88b17a6479202ff5fe5f580fc3404922cd02ab3716197adf1ef628029"},
+    {file = "lxml-5.2.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:56c22432809085b3f3ae04e6e7bdd36883d7258fcd90e53ba7b2e463efc7a6af"},
+    {file = "lxml-5.2.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a55ee573116ba208932e2d1a037cc4b10d2c1cb264ced2184d00b18ce585b2c0"},
+    {file = "lxml-5.2.1-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:6cf58416653c5901e12624e4013708b6e11142956e7f35e7a83f1ab02f3fe456"},
+    {file = "lxml-5.2.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:64c2baa7774bc22dd4474248ba16fe1a7f611c13ac6123408694d4cc93d66dbd"},
+    {file = "lxml-5.2.1-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:74b28c6334cca4dd704e8004cba1955af0b778cf449142e581e404bd211fb619"},
+    {file = "lxml-5.2.1-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:7221d49259aa1e5a8f00d3d28b1e0b76031655ca74bb287123ef56c3db92f213"},
+    {file = "lxml-5.2.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:3dbe858ee582cbb2c6294dc85f55b5f19c918c2597855e950f34b660f1a5ede6"},
+    {file = "lxml-5.2.1-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:04ab5415bf6c86e0518d57240a96c4d1fcfc3cb370bb2ac2a732b67f579e5a04"},
+    {file = "lxml-5.2.1-cp37-cp37m-musllinux_1_2_ppc64le.whl", hash = "sha256:6ab833e4735a7e5533711a6ea2df26459b96f9eec36d23f74cafe03631647c41"},
+    {file = "lxml-5.2.1-cp37-cp37m-musllinux_1_2_s390x.whl", hash = "sha256:f443cdef978430887ed55112b491f670bba6462cea7a7742ff8f14b7abb98d75"},
+    {file = "lxml-5.2.1-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:9e2addd2d1866fe112bc6f80117bcc6bc25191c5ed1bfbcf9f1386a884252ae8"},
+    {file = "lxml-5.2.1-cp37-cp37m-win32.whl", hash = "sha256:f51969bac61441fd31f028d7b3b45962f3ecebf691a510495e5d2cd8c8092dbd"},
+    {file = "lxml-5.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:b0b58fbfa1bf7367dde8a557994e3b1637294be6cf2169810375caf8571a085c"},
+    {file = "lxml-5.2.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:3e183c6e3298a2ed5af9d7a356ea823bccaab4ec2349dc9ed83999fd289d14d5"},
+    {file = "lxml-5.2.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:804f74efe22b6a227306dd890eecc4f8c59ff25ca35f1f14e7482bbce96ef10b"},
+    {file = "lxml-5.2.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:08802f0c56ed150cc6885ae0788a321b73505d2263ee56dad84d200cab11c07a"},
+    {file = "lxml-5.2.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0f8c09ed18ecb4ebf23e02b8e7a22a05d6411911e6fabef3a36e4f371f4f2585"},
+    {file = "lxml-5.2.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e3d30321949861404323c50aebeb1943461a67cd51d4200ab02babc58bd06a86"},
+    {file = "lxml-5.2.1-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:b560e3aa4b1d49e0e6c847d72665384db35b2f5d45f8e6a5c0072e0283430533"},
+    {file = "lxml-5.2.1-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:058a1308914f20784c9f4674036527e7c04f7be6fb60f5d61353545aa7fcb739"},
+    {file = "lxml-5.2.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:adfb84ca6b87e06bc6b146dc7da7623395db1e31621c4785ad0658c5028b37d7"},
+    {file = "lxml-5.2.1-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:417d14450f06d51f363e41cace6488519038f940676ce9664b34ebf5653433a5"},
+    {file = "lxml-5.2.1-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:a2dfe7e2473f9b59496247aad6e23b405ddf2e12ef0765677b0081c02d6c2c0b"},
+    {file = "lxml-5.2.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:bf2e2458345d9bffb0d9ec16557d8858c9c88d2d11fed53998512504cd9df49b"},
+    {file = "lxml-5.2.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:58278b29cb89f3e43ff3e0c756abbd1518f3ee6adad9e35b51fb101c1c1daaec"},
+    {file = "lxml-5.2.1-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:64641a6068a16201366476731301441ce93457eb8452056f570133a6ceb15fca"},
+    {file = "lxml-5.2.1-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:78bfa756eab503673991bdcf464917ef7845a964903d3302c5f68417ecdc948c"},
+    {file = "lxml-5.2.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:11a04306fcba10cd9637e669fd73aa274c1c09ca64af79c041aa820ea992b637"},
+    {file = "lxml-5.2.1-cp38-cp38-win32.whl", hash = "sha256:66bc5eb8a323ed9894f8fa0ee6cb3e3fb2403d99aee635078fd19a8bc7a5a5da"},
+    {file = "lxml-5.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:9676bfc686fa6a3fa10cd4ae6b76cae8be26eb5ec6811d2a325636c460da1806"},
+    {file = "lxml-5.2.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:cf22b41fdae514ee2f1691b6c3cdeae666d8b7fa9434de445f12bbeee0cf48dd"},
+    {file = "lxml-5.2.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ec42088248c596dbd61d4ae8a5b004f97a4d91a9fd286f632e42e60b706718d7"},
+    {file = "lxml-5.2.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cd53553ddad4a9c2f1f022756ae64abe16da1feb497edf4d9f87f99ec7cf86bd"},
+    {file = "lxml-5.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:feaa45c0eae424d3e90d78823f3828e7dc42a42f21ed420db98da2c4ecf0a2cb"},
+    {file = "lxml-5.2.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ddc678fb4c7e30cf830a2b5a8d869538bc55b28d6c68544d09c7d0d8f17694dc"},
+    {file = "lxml-5.2.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:853e074d4931dbcba7480d4dcab23d5c56bd9607f92825ab80ee2bd916edea53"},
+    {file = "lxml-5.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc4691d60512798304acb9207987e7b2b7c44627ea88b9d77489bbe3e6cc3bd4"},
+    {file = "lxml-5.2.1-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:beb72935a941965c52990f3a32d7f07ce869fe21c6af8b34bf6a277b33a345d3"},
+    {file = "lxml-5.2.1-cp39-cp39-manylinux_2_28_ppc64le.whl", hash = "sha256:6588c459c5627fefa30139be4d2e28a2c2a1d0d1c265aad2ba1935a7863a4913"},
+    {file = "lxml-5.2.1-cp39-cp39-manylinux_2_28_s390x.whl", hash = "sha256:588008b8497667f1ddca7c99f2f85ce8511f8f7871b4a06ceede68ab62dff64b"},
+    {file = "lxml-5.2.1-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:b6787b643356111dfd4032b5bffe26d2f8331556ecb79e15dacb9275da02866e"},
+    {file = "lxml-5.2.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:7c17b64b0a6ef4e5affae6a3724010a7a66bda48a62cfe0674dabd46642e8b54"},
+    {file = "lxml-5.2.1-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:27aa20d45c2e0b8cd05da6d4759649170e8dfc4f4e5ef33a34d06f2d79075d57"},
+    {file = "lxml-5.2.1-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:d4f2cc7060dc3646632d7f15fe68e2fa98f58e35dd5666cd525f3b35d3fed7f8"},
+    {file = "lxml-5.2.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ff46d772d5f6f73564979cd77a4fffe55c916a05f3cb70e7c9c0590059fb29ef"},
+    {file = "lxml-5.2.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:96323338e6c14e958d775700ec8a88346014a85e5de73ac7967db0367582049b"},
+    {file = "lxml-5.2.1-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:52421b41ac99e9d91934e4d0d0fe7da9f02bfa7536bb4431b4c05c906c8c6919"},
+    {file = "lxml-5.2.1-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:7a7efd5b6d3e30d81ec68ab8a88252d7c7c6f13aaa875009fe3097eb4e30b84c"},
+    {file = "lxml-5.2.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:0ed777c1e8c99b63037b91f9d73a6aad20fd035d77ac84afcc205225f8f41188"},
+    {file = "lxml-5.2.1-cp39-cp39-win32.whl", hash = "sha256:644df54d729ef810dcd0f7732e50e5ad1bd0a135278ed8d6bcb06f33b6b6f708"},
+    {file = "lxml-5.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:9ca66b8e90daca431b7ca1408cae085d025326570e57749695d6a01454790e95"},
+    {file = "lxml-5.2.1-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:9b0ff53900566bc6325ecde9181d89afadc59c5ffa39bddf084aaedfe3b06a11"},
+    {file = "lxml-5.2.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd6037392f2d57793ab98d9e26798f44b8b4da2f2464388588f48ac52c489ea1"},
+    {file = "lxml-5.2.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b9c07e7a45bb64e21df4b6aa623cb8ba214dfb47d2027d90eac197329bb5e94"},
+    {file = "lxml-5.2.1-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:3249cc2989d9090eeac5467e50e9ec2d40704fea9ab72f36b034ea34ee65ca98"},
+    {file = "lxml-5.2.1-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:f42038016852ae51b4088b2862126535cc4fc85802bfe30dea3500fdfaf1864e"},
+    {file = "lxml-5.2.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:533658f8fbf056b70e434dff7e7aa611bcacb33e01f75de7f821810e48d1bb66"},
+    {file = "lxml-5.2.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:622020d4521e22fb371e15f580d153134bfb68d6a429d1342a25f051ec72df1c"},
+    {file = "lxml-5.2.1-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:efa7b51824aa0ee957ccd5a741c73e6851de55f40d807f08069eb4c5a26b2baa"},
+    {file = "lxml-5.2.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c6ad0fbf105f6bcc9300c00010a2ffa44ea6f555df1a2ad95c88f5656104817"},
+    {file = "lxml-5.2.1-pp37-pypy37_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:e233db59c8f76630c512ab4a4daf5a5986da5c3d5b44b8e9fc742f2a24dbd460"},
+    {file = "lxml-5.2.1-pp37-pypy37_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:6a014510830df1475176466b6087fc0c08b47a36714823e58d8b8d7709132a96"},
+    {file = "lxml-5.2.1-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:d38c8f50ecf57f0463399569aa388b232cf1a2ffb8f0a9a5412d0db57e054860"},
+    {file = "lxml-5.2.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:5aea8212fb823e006b995c4dda533edcf98a893d941f173f6c9506126188860d"},
+    {file = "lxml-5.2.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff097ae562e637409b429a7ac958a20aab237a0378c42dabaa1e3abf2f896e5f"},
+    {file = "lxml-5.2.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f5d65c39f16717a47c36c756af0fb36144069c4718824b7533f803ecdf91138"},
+    {file = "lxml-5.2.1-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:3d0c3dd24bb4605439bf91068598d00c6370684f8de4a67c2992683f6c309d6b"},
+    {file = "lxml-5.2.1-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:e32be23d538753a8adb6c85bd539f5fd3b15cb987404327c569dfc5fd8366e85"},
+    {file = "lxml-5.2.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:cc518cea79fd1e2f6c90baafa28906d4309d24f3a63e801d855e7424c5b34144"},
+    {file = "lxml-5.2.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a0af35bd8ebf84888373630f73f24e86bf016642fb8576fba49d3d6b560b7cbc"},
+    {file = "lxml-5.2.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8aca2e3a72f37bfc7b14ba96d4056244001ddcc18382bd0daa087fd2e68a354"},
+    {file = "lxml-5.2.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ca1e8188b26a819387b29c3895c47a5e618708fe6f787f3b1a471de2c4a94d9"},
+    {file = "lxml-5.2.1-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c8ba129e6d3b0136a0f50345b2cb3db53f6bda5dd8c7f5d83fbccba97fb5dcb5"},
+    {file = "lxml-5.2.1-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:e998e304036198b4f6914e6a1e2b6f925208a20e2042563d9734881150c6c246"},
+    {file = "lxml-5.2.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:d3be9b2076112e51b323bdf6d5a7f8a798de55fb8d95fcb64bd179460cdc0704"},
+    {file = "lxml-5.2.1.tar.gz", hash = "sha256:3f7765e69bbce0906a7c74d5fe46d2c7a7596147318dbc08e4a2431f3060e306"},
+]
+
+[package.extras]
+cssselect = ["cssselect (>=0.7)"]
+html-clean = ["lxml-html-clean"]
+html5 = ["html5lib"]
+htmlsoup = ["BeautifulSoup4"]
+source = ["Cython (>=3.0.10)"]
 
 [[package]]
 name = "markdown"
@@ -6968,4 +7182,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.8,<3.12"
-content-hash = "06b737bd188446ff03e850fd6965f369f42f35056f2d4fa22a3cc99aabe1c611"
+content-hash = "97377b70a47ed3c5ddcb340936f28edc38615d5947c23b11000c5cbca1779b21"

--- a/poetry.lock
+++ b/poetry.lock
@@ -7182,4 +7182,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.8,<3.12"
-content-hash = "97377b70a47ed3c5ddcb340936f28edc38615d5947c23b11000c5cbca1779b21"
+content-hash = "4711d6697cab31689989b7c67ca5947379beec05f79725d2bbc9c02df8114661"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ fastapi = "^0.104.1"
 celery = {version = "^5.3.6", extras = ["redis"]}
 uvicorn = "*"
 pydantic-settings = "^2.2.1"
+label-studio-sdk = "^0.0.32"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.4.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ jupyterlab = "^4.0.10"
 jupyter-client = "8.4.0"
 matplotlib = "^3.7.4"
 
+[tool.poetry.group.label-studio]
+optional = true
+
 [tool.poetry.group.label-studio.dependencies]
 label-studio-sdk = "^0.0.32"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ fastapi = "^0.104.1"
 celery = {version = "^5.3.6", extras = ["redis"]}
 uvicorn = "*"
 pydantic-settings = "^2.2.1"
-label-studio-sdk = "^0.0.32"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.4.3"
@@ -51,6 +50,9 @@ jupyter = "^1.0.0"
 jupyterlab = "^4.0.10"
 jupyter-client = "8.4.0"
 matplotlib = "^3.7.4"
+
+[tool.poetry.group.label-studio.dependencies]
+label-studio-sdk = "^0.0.32"
 
 [tool.poetry.scripts]
 adala = "adala.cli:main"

--- a/server/app.py
+++ b/server/app.py
@@ -31,19 +31,6 @@ from server.handlers.result_handlers import ResultHandler
 logger = logging.getLogger(__name__)
 
 
-class Settings(BaseSettings):
-    """
-    Can hardcode settings here, read from env file, or pass as env vars
-    https://docs.pydantic.dev/latest/concepts/pydantic_settings/#field-value-priority
-    """
-
-    kafka_bootstrap_servers: Union[str, List[str]]
-
-    model_config = SettingsConfigDict(
-        env_file=".env",
-    )
-
-
 settings = Settings()
 
 app = fastapi.FastAPI()

--- a/server/app.py
+++ b/server/app.py
@@ -158,11 +158,13 @@ class SubmitStreamingRequest(BaseModel):
 
     @field_validator("result_handler", mode="before")
     def validate_result_handler(cls, value: Dict) -> ResultHandler:
-        '''
+        """
         Allows polymorphism for ResultHandlers created from a dict; same implementation as the Skills, Environment, and Runtime within an Agent
-        '''
+        """
         if "type" not in value:
-            raise HTTPException(status_code=400, detail="Missing type in result_handler")
+            raise HTTPException(
+                status_code=400, detail="Missing type in result_handler"
+            )
         result_handler = ResultHandler.create_from_registry(value.pop("type"), **value)
         return result_handler
 
@@ -227,9 +229,7 @@ async def submit_streaming(request: SubmitStreamingRequest):
 
     task = process_streaming_output
     logger.info(f"Submitting task {task.name}")
-    # serialized_result_handler = pickle.dumps(request.result_handler)
     output_result = task.delay(
-        # job_id=input_job_id, serialized_result_handler=serialized_result_handler
         job_id=input_job_id, result_handler=request.result_handler
     )
     output_job_id = output_result.id

--- a/server/app.py
+++ b/server/app.py
@@ -139,7 +139,7 @@ class SubmitStreamingRequest(BaseModel):
     """
 
     agent: Agent
-    # SerializeAsAny is for allowing subclasses of ResultHandler
+    # SerializeAsAny allows for subclasses of ResultHandler
     result_handler: SerializeAsAny[ResultHandler]
     task_name: str = "process_file_streaming"
 
@@ -147,6 +147,8 @@ class SubmitStreamingRequest(BaseModel):
     def validate_result_handler(cls, value: Dict) -> ResultHandler:
         """
         Allows polymorphism for ResultHandlers created from a dict; same implementation as the Skills, Environment, and Runtime within an Agent
+        "type" is the name of the subclass of ResultHandler being used. Currently available subclasses: LSEHandler, DummyHandler
+        Look in server/handlers/result_handlers.py for available subclasses
         """
         if "type" not in value:
             raise HTTPException(
@@ -186,7 +188,7 @@ async def submit(request: SubmitRequest):
     task = process_file
     agent = request.agent
 
-    logger.debug(f"Submitting task {task.name} with agent {agent}")
+    logger.info(f"Submitting task {task.name} with agent {agent}")
     result = task.delay(agent=agent)
     logger.debug(f"Task {task.name} submitted with job_id {result.id}")
 
@@ -212,15 +214,15 @@ async def submit_streaming(request: SubmitStreamingRequest):
     logger.info(f"Submitting task {task.name} with agent {agent}")
     input_result = task.delay(agent=agent)
     input_job_id = input_result.id
-    logger.info(f"Task {task.name} submitted with job_id {input_job_id}")
+    logger.debug(f"Task {task.name} submitted with job_id {input_job_id}")
 
     task = process_streaming_output
-    logger.info(f"Submitting task {task.name}")
+    logger.debug(f"Submitting task {task.name}")
     output_result = task.delay(
         job_id=input_job_id, result_handler=request.result_handler
     )
     output_job_id = output_result.id
-    logger.info(f"Task {task.name} submitted with job_id {output_job_id}")
+    logger.debug(f"Task {task.name} submitted with job_id {output_job_id}")
 
     return Response[JobCreated](data=JobCreated(job_id=input_job_id))
 

--- a/server/app.py
+++ b/server/app.py
@@ -152,7 +152,7 @@ class SubmitStreamingRequest(BaseModel):
     """
 
     agent: Agent
-    result_handler: str
+    result_handler: ResultHandler
     task_name: str = "process_file_streaming"
 
 
@@ -216,8 +216,9 @@ async def submit_streaming(request: SubmitStreamingRequest):
 
     task = process_streaming_output
     logger.info(f"Submitting task {task.name}")
+    serialized_result_handler = pickle.dumps(request.result_handler)
     output_result = task.delay(
-        job_id=input_job_id, result_handler=request.result_handler
+        job_id=input_job_id, serialized_result_handler=serialized_result_handler
     )
     output_job_id = output_result.id
     logger.info(f"Task {task.name} submitted with job_id {output_job_id}")

--- a/server/app.py
+++ b/server/app.py
@@ -24,7 +24,8 @@ from tasks.process_file import (
     process_file_streaming,
     process_streaming_output,
 )
-from utils import get_input_topic, ResultHandler, Settings
+from utils import get_input_topic, Settings
+from server.handlers.result_handlers import ResultHandler
 
 
 logger = logging.getLogger(__name__)
@@ -194,10 +195,10 @@ async def submit(request: SubmitRequest):
 
     # TODO: get task by name, e.g. request.task_name
     task = process_file
-    serialized_agent = pickle.dumps(request.agent)
+    agent = request.agent
 
-    logger.debug(f"Submitting task {task.name} with agent {serialized_agent}")
-    result = task.delay(serialized_agent=serialized_agent)
+    logger.debug(f"Submitting task {task.name} with agent {agent}")
+    result = task.delay(agent=agent)
     logger.debug(f"Task {task.name} submitted with job_id {result.id}")
 
     return Response[JobCreated](data=JobCreated(job_id=result.id))
@@ -217,18 +218,19 @@ async def submit_streaming(request: SubmitStreamingRequest):
 
     # TODO: get task by name, e.g. request.task_name
     task = process_file_streaming
-    serialized_agent = pickle.dumps(request.agent)
+    agent = request.agent
 
-    logger.info(f"Submitting task {task.name} with agent {serialized_agent}")
-    input_result = task.delay(serialized_agent=serialized_agent)
+    logger.info(f"Submitting task {task.name} with agent {agent}")
+    input_result = task.delay(agent=agent)
     input_job_id = input_result.id
     logger.info(f"Task {task.name} submitted with job_id {input_job_id}")
 
     task = process_streaming_output
     logger.info(f"Submitting task {task.name}")
-    serialized_result_handler = pickle.dumps(request.result_handler)
+    # serialized_result_handler = pickle.dumps(request.result_handler)
     output_result = task.delay(
-        job_id=input_job_id, serialized_result_handler=serialized_result_handler
+        # job_id=input_job_id, serialized_result_handler=serialized_result_handler
+        job_id=input_job_id, result_handler=request.result_handler
     )
     output_job_id = output_result.id
     logger.info(f"Task {task.name} submitted with job_id {output_job_id}")

--- a/server/handlers/result_handlers.py
+++ b/server/handlers/result_handlers.py
@@ -29,6 +29,7 @@ class ResultHandler(BaseModelInRegistry):
     }
     ```
     """
+
     @abstractmethod
     def __call__(self, result_batch: list[dict]) -> None:
         """

--- a/server/handlers/result_handlers.py
+++ b/server/handlers/result_handlers.py
@@ -20,7 +20,7 @@ class ResultHandler(BaseModelInRegistry):
 
     Subclasses must implement the `__call__` method.
 
-    BaseModelInRegistry is a utility class that allows polymorphic instantiation of ResultHandlers through passing in the class name as the "type" field in the request, for example:
+    The BaseModelInRegistry base class implements a factory pattern, allowing the "type" parameter to specify which subclass of ResultHandler to instantiate. For example:
     ```json
     result_handler: {
         "type": "DummyHandler",

--- a/server/handlers/result_handlers.py
+++ b/server/handlers/result_handlers.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import logging
 import json
 from abc import abstractmethod
@@ -37,7 +38,7 @@ class LSEHandler(ResultHandler):
 
     api_key: str
     url: str
-    job_id: str
+    job_id: Optional[str] = None
 
     @computed_field
     def client(self) -> Client:
@@ -45,6 +46,9 @@ class LSEHandler(ResultHandler):
             api_key=self.api_key,
             url=self.url,
         )
+
+    def set_job_id(self, job_id):
+        self.job_id = job_id
 
     @model_validator(mode="after")
     def ready(self):

--- a/server/handlers/result_handlers.py
+++ b/server/handlers/result_handlers.py
@@ -12,10 +12,10 @@ logger = logging.getLogger(__name__)
 try:
     from label_studio_sdk import Client as LSEClient
 except ImportError:
-    logger.warning("Label Studio SDK not found. LSEHandler will not be available.")
+    logger.warning("Label Studio SDK not found. LSEHandler will not be available. Run `poetry install --with label-studio` to fix")
     class LSEClient:
         def __init__(self, *args, **kwargs):
-            logger.error("Label Studio SDK not found. LSEHandler is not available.")
+            logger.error("Label Studio SDK not found. LSEHandler is not available. Run `poetry install --with label-studio` to fix")
 
 
 class ResultHandler(BaseModelInRegistry):

--- a/server/handlers/result_handlers.py
+++ b/server/handlers/result_handlers.py
@@ -5,10 +5,17 @@ from abc import abstractmethod
 from pydantic import computed_field, ConfigDict, model_validator
 
 from adala.utils.registry import BaseModelInRegistry
-from label_studio_sdk import Client
 
 
 logger = logging.getLogger(__name__)
+
+try:
+    from label_studio_sdk import Client as LSEClient
+except ImportError:
+    logger.warning("Label Studio SDK not found. LSEHandler will not be available.")
+    class LSEClient:
+        def __init__(self, *args, **kwargs):
+            logger.error("Label Studio SDK not found. LSEHandler is not available.")
 
 
 class ResultHandler(BaseModelInRegistry):
@@ -59,8 +66,8 @@ class LSEHandler(ResultHandler):
     modelrun_id: int
 
     @computed_field
-    def client(self) -> Client:
-        _client = Client(
+    def client(self) -> LSEClient:
+        _client = LSEClient(
             api_key=self.api_key,
             url=self.url,
         )

--- a/server/handlers/result_handlers.py
+++ b/server/handlers/result_handlers.py
@@ -1,4 +1,3 @@
-
 import logging
 import json
 from abc import abstractmethod
@@ -12,12 +11,12 @@ logger = logging.getLogger(__name__)
 
 
 class ResultHandler(BaseModelInRegistry):
-
     @abstractmethod
     def __call__(self, batch):
-        '''
+        """
         Callable to do something with a batch of results.
-        '''
+        """
+
 
 class DummyHandler(ResultHandler):
     """
@@ -33,6 +32,7 @@ class LSEHandler(ResultHandler):
     """
     Handler to use the Label Studio SDK to load a batch of results back into a Label Studio project
     """
+
     model_config = ConfigDict(arbitrary_types_allowed=True)  # for @computed_field
 
     api_key: str
@@ -51,8 +51,8 @@ class LSEHandler(ResultHandler):
         # Need this to make POST requests using the SDK client
         self.client.headers.update(
             {
-                'accept': 'application/json',
-                'Content-Type': 'application/json',
+                "accept": "application/json",
+                "Content-Type": "application/json",
             }
         )
 
@@ -67,13 +67,8 @@ class LSEHandler(ResultHandler):
             "/api/model-run/batch-predictions",
             data=json.dumps(
                 {
-                    'job_id': self.job_id,
-                    'results': batch,
+                    "job_id": self.job_id,
+                    "results": batch,
                 }
             ),
         )
-
-
-# class ResultHandler(Enum):
-    # DUMMY = dummy_handler
-    # LSE = LSEHandler

--- a/server/handlers/result_handlers.py
+++ b/server/handlers/result_handlers.py
@@ -12,10 +12,15 @@ logger = logging.getLogger(__name__)
 try:
     from label_studio_sdk import Client as LSEClient
 except ImportError:
-    logger.warning("Label Studio SDK not found. LSEHandler will not be available. Run `poetry install --with label-studio` to fix")
+    logger.warning(
+        "Label Studio SDK not found. LSEHandler will not be available. Run `poetry install --with label-studio` to fix"
+    )
+
     class LSEClient:
         def __init__(self, *args, **kwargs):
-            logger.error("Label Studio SDK not found. LSEHandler is not available. Run `poetry install --with label-studio` to fix")
+            logger.error(
+                "Label Studio SDK not found. LSEHandler is not available. Run `poetry install --with label-studio` to fix"
+            )
 
 
 class ResultHandler(BaseModelInRegistry):

--- a/server/handlers/result_handlers.py
+++ b/server/handlers/result_handlers.py
@@ -38,7 +38,7 @@ class LSEHandler(ResultHandler):
 
     api_key: str
     url: str
-    job_id: Optional[str] = None
+    modelrun_id: int
 
     @computed_field
     def client(self) -> Client:
@@ -56,9 +56,6 @@ class LSEHandler(ResultHandler):
         )
         return _client
 
-    def set_job_id(self, job_id):
-        self.job_id = job_id
-
     @model_validator(mode="after")
     def ready(self):
         conn = self.client.check_connection()
@@ -73,7 +70,7 @@ class LSEHandler(ResultHandler):
             "/api/model-run/batch-predictions",
             data=json.dumps(
                 {
-                    "job_id": self.job_id,
+                    "modelrun_id": self.modelrun_id,
                     "results": batch,
                 }
             ),

--- a/server/handlers/result_handlers.py
+++ b/server/handlers/result_handlers.py
@@ -61,9 +61,8 @@ class LSEHandler(ResultHandler):
 
     @model_validator(mode="after")
     def ready(self):
-
         conn = self.client.check_connection()
-        assert conn['status'] == 'UP', 'Label Studio is not available'
+        assert conn["status"] == "UP", "Label Studio is not available"
 
         return self
 

--- a/server/handlers/result_handlers.py
+++ b/server/handlers/result_handlers.py
@@ -1,0 +1,79 @@
+
+import logging
+import json
+from abc import abstractmethod
+from pydantic import computed_field, ConfigDict, model_validator
+
+from adala.utils.registry import BaseModelInRegistry
+from label_studio_sdk import Client
+
+
+logger = logging.getLogger(__name__)
+
+
+class ResultHandler(BaseModelInRegistry):
+
+    @abstractmethod
+    def __call__(self, batch):
+        '''
+        Callable to do something with a batch of results.
+        '''
+
+class DummyHandler(ResultHandler):
+    """
+    Dummy handler to test streaming output flow
+    Can delete once we have a real handler
+    """
+
+    def __call__(self, batch):
+        logger.info(f"\n\nHandler received batch: {batch}\n\n")
+
+
+class LSEHandler(ResultHandler):
+    """
+    Handler to use the Label Studio SDK to load a batch of results back into a Label Studio project
+    """
+    model_config = ConfigDict(arbitrary_types_allowed=True)  # for @computed_field
+
+    api_key: str
+    url: str
+    job_id: str
+
+    @computed_field
+    def client(self) -> Client:
+        return Client(
+            api_key=self.api_key,
+            url=self.url,
+        )
+
+    @model_validator(mode="after")
+    def ready(self):
+        # Need this to make POST requests using the SDK client
+        self.client.headers.update(
+            {
+                'accept': 'application/json',
+                'Content-Type': 'application/json',
+            }
+        )
+
+        self.client.check_connection()
+
+        return self
+
+    def __call__(self, batch):
+        logger.info(f"\n\nHandler received batch: {batch}\n\n")
+        self.client.make_request(
+            "POST",
+            "/api/model-run/batch-predictions",
+            data=json.dumps(
+                {
+                    'job_id': self.job_id,
+                    'results': batch,
+                }
+            ),
+        )
+
+
+# class ResultHandler(Enum):
+    # DUMMY = dummy_handler
+    # LSE = LSEHandler

--- a/server/tasks/process_file.py
+++ b/server/tasks/process_file.py
@@ -49,11 +49,15 @@ async def async_process_streaming_output(
 ):
     logger.info(f"Polling for results {input_job_id=}")
 
+
     try:
+        import server.utils as utils
         # result_handler = ResultHandler.__dict__[result_handler]
         result_handler = pickle.loads(serialized_result_handler)
-        assert isinstance(result_handler, ResultHandler)
+        # assert isinstance(result_handler, ResultHandler)
     except Exception as e:
+        from celery.contrib import rdb
+        rdb.set_trace()
         # logger.error(f"{result_handler} is not a valid ResultHandler")
         logger.error(f"not a valid ResultHandler")
         raise e

--- a/server/tasks/process_file.py
+++ b/server/tasks/process_file.py
@@ -16,12 +16,13 @@ from server.handlers.result_handlers import ResultHandler
 logger = logging.getLogger(__name__)
 
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
-app = Celery("worker", broker=REDIS_URL, backend=REDIS_URL, accept_content=["json", "pickle"])
+app = Celery(
+    "worker", broker=REDIS_URL, backend=REDIS_URL, accept_content=["json", "pickle"]
+)
 
 
-@app.task(name="process_file", track_started=True, serializer='pickle')
+@app.task(name="process_file", track_started=True, serializer="pickle")
 def process_file(agent: Agent):
-
     # # Read data from a file and send it to the Kafka input topic
     asyncio.run(agent.environment.initialize())
 
@@ -32,9 +33,10 @@ def process_file(agent: Agent):
     asyncio.run(agent.environment.finalize())
 
 
-@app.task(name="process_file_streaming", track_started=True, bind=True, serializer='pickle')
+@app.task(
+    name="process_file_streaming", track_started=True, bind=True, serializer="pickle"
+)
 def process_file_streaming(self, agent: Agent):
-
     # Get own job ID to set Consumer topic accordingly
     job_id = self.request.id
     agent.environment.kafka_input_topic = get_input_topic(job_id)
@@ -48,19 +50,6 @@ async def async_process_streaming_output(
     input_job_id: str, result_handler: ResultHandler, batch_size: int
 ):
     logger.info(f"Polling for results {input_job_id=}")
-
-
-    # try:
-        # import server.utils as utils
-        # # result_handler = ResultHandler.__dict__[result_handler]
-        # result_handler = pickle.loads(serialized_result_handler)
-        # # assert isinstance(result_handler, ResultHandler)
-    # except Exception as e:
-    # from celery.contrib import rdb
-    # rdb.set_trace()
-        # # logger.error(f"{result_handler} is not a valid ResultHandler")
-        # logger.error(f"not a valid ResultHandler")
-        # raise e
 
     topic = get_output_topic(input_job_id)
     settings = Settings()
@@ -98,7 +87,9 @@ async def async_process_streaming_output(
     await consumer.stop()
 
 
-@app.task(name="process_streaming_output", track_started=True, bind=True, serializer='pickle')
+@app.task(
+    name="process_streaming_output", track_started=True, bind=True, serializer="pickle"
+)
 def process_streaming_output(
     self, job_id: str, result_handler: ResultHandler, batch_size: int = 2
 ):

--- a/server/tasks/process_file.py
+++ b/server/tasks/process_file.py
@@ -70,12 +70,12 @@ async def async_process_streaming_output(
             data = await consumer.getmany(timeout_ms=3000, max_records=batch_size)
             for tp, messages in data.items():
                 if messages:
-                    logger.info(f"Handling {messages=} in topic {tp.topic}")
+                    logger.debug(f"Handling {messages=} in topic {tp.topic}")
                     data = [msg.value for msg in messages]
                     result_handler(data)
-                    logger.info(f"Handled {len(messages)} messages in topic {tp.topic}")
+                    logger.debug(f"Handled {len(messages)} messages in topic {tp.topic}")
                 else:
-                    logger.info(f"No messages in topic {tp.topic}")
+                    logger.debug(f"No messages in topic {tp.topic}")
             if not data:
                 logger.info(f"No messages in any topic")
         finally:
@@ -102,7 +102,7 @@ def process_streaming_output(
         # Set own status to failure
         self.update_state(state=states.FAILURE)
 
-        logger.log(level=logging.ERROR, msg=e)
+        logger.error(msg=e)
 
         # Ignore the task so no other state is recorded
         # TODO check if this updates state to Ignored, or keeps Failed

--- a/server/tasks/process_file.py
+++ b/server/tasks/process_file.py
@@ -73,7 +73,9 @@ async def async_process_streaming_output(
             data = await consumer.getmany(timeout_ms=3000, max_records=batch_size)
             for tp, messages in data.items():
                 if messages:
-                    result_handler(messages)
+                    logger.info(f"Handling {messages=} in topic {tp.topic}")
+                    data = [msg.value for msg in messages]
+                    result_handler(data)
                     logger.info(f"Handled {len(messages)} messages in topic {tp.topic}")
                 else:
                     logger.info(f"No messages in topic {tp.topic}")

--- a/server/tasks/process_file.py
+++ b/server/tasks/process_file.py
@@ -73,7 +73,9 @@ async def async_process_streaming_output(
                     logger.debug(f"Handling {messages=} in topic {tp.topic}")
                     data = [msg.value for msg in messages]
                     result_handler(data)
-                    logger.debug(f"Handled {len(messages)} messages in topic {tp.topic}")
+                    logger.debug(
+                        f"Handled {len(messages)} messages in topic {tp.topic}"
+                    )
                 else:
                     logger.debug(f"No messages in topic {tp.topic}")
             if not data:

--- a/server/tasks/process_file.py
+++ b/server/tasks/process_file.py
@@ -51,9 +51,6 @@ async def async_process_streaming_output(
 ):
     logger.info(f"Polling for results {input_job_id=}")
 
-    # FIXME switch to model_run_id or find a way to pass this in
-    result_handler.set_job_id(input_job_id)
-
     topic = get_output_topic(input_job_id)
     settings = Settings()
 

--- a/server/tasks/process_file.py
+++ b/server/tasks/process_file.py
@@ -51,6 +51,9 @@ async def async_process_streaming_output(
 ):
     logger.info(f"Polling for results {input_job_id=}")
 
+    # FIXME switch to model_run_id or find a way to pass this in
+    result_handler.set_job_id(input_job_id)
+
     topic = get_output_topic(input_job_id)
     settings = Settings()
 
@@ -78,6 +81,7 @@ async def async_process_streaming_output(
                 logger.info(f"No messages in any topic")
         finally:
             job = process_file_streaming.AsyncResult(input_job_id)
+            # TODO no way to recover here if connection to main app is lost, job will be stuck at "PENDING" so this will loop forever
             if job.status in ["SUCCESS", "FAILURE", "REVOKED"]:
                 input_job_running = False
                 logger.info(f"Input job done, stopping output job")

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,8 +1,14 @@
 import logging
+import json
 
-from enum import Enum
+# from enum import Enum
+from abc import abstractmethod
+from pydantic import BaseModel, computed_field, ConfigDict, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import List, Union
+
+from label_studio_sdk import Client
+
 
 logger = logging.getLogger(__name__)
 
@@ -20,17 +26,72 @@ class Settings(BaseSettings):
     )
 
 
-def dummy_handler(batch):
+class ResultHandler(BaseModel):
+
+    @abstractmethod
+    def __call__(self, batch):
+        '''
+        Callable to do something with a batch of results.
+        '''
+
+class DummyHandler(ResultHandler):
     """
     Dummy handler to test streaming output flow
     Can delete once we have a real handler
     """
 
-    logger.info(f"\n\nHandler received batch: {batch}\n\n")
+    def __call__(self, batch):
+        logger.info(f"\n\nHandler received batch: {batch}\n\n")
 
 
-class ResultHandler(Enum):
-    DUMMY = dummy_handler
+class LSEHandler(ResultHandler):
+    """
+    Handler to use the Label Studio SDK to load a batch of results back into a Label Studio project
+    """
+    model_config = ConfigDict(arbitrary_types_allowed=True)  # for @computed_field
+
+    api_key: str
+    url: str
+    job_id: str
+
+    @computed_field
+    def client(self) -> Client:
+        return Client(
+            api_key=self.api_key,
+            url=self.url,
+        )
+
+    @model_validator(mode="after")
+    def ready(self):
+        # Need this to make POST requests using the SDK client
+        self.client.headers.update(
+            {
+                'accept': 'application/json',
+                'Content-Type': 'application/json',
+            }
+        )
+
+        self.client.check_connection()
+
+        return self
+
+    def __call__(self, batch):
+        logger.info(f"\n\nHandler received batch: {batch}\n\n")
+        self.client.make_request(
+            "POST",
+            "/api/model-run/batch-predictions",
+            data=json.dumps(
+                {
+                    'job_id': self.job_id,
+                    'results': batch,
+                }
+            ),
+        )
+
+
+# class ResultHandler(Enum):
+    # DUMMY = dummy_handler
+    # LSE = LSEHandler
 
 
 def get_input_topic(job_id: str):

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,18 +1,7 @@
-import logging
-import json
-
 # from enum import Enum
-from abc import abstractmethod
-from pydantic import BaseModel, computed_field, ConfigDict, model_validator, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import List, Union
-
-from adala.utils.registry import BaseModelInRegistry
-
-from label_studio_sdk import Client
-
-
-logger = logging.getLogger(__name__)
+from pathlib import Path
 
 
 class Settings(BaseSettings):
@@ -24,76 +13,9 @@ class Settings(BaseSettings):
     kafka_bootstrap_servers: Union[str, List[str]]
 
     model_config = SettingsConfigDict(
-        env_file=".env",
+        # have to use an absolute path here so celery workers can find it
+        env_file=(Path(__file__).parent / ".env"),
     )
-
-
-class ResultHandler(BaseModelInRegistry):
-
-    @abstractmethod
-    def __call__(self, batch):
-        '''
-        Callable to do something with a batch of results.
-        '''
-
-class DummyHandler(ResultHandler):
-    """
-    Dummy handler to test streaming output flow
-    Can delete once we have a real handler
-    """
-
-    def __call__(self, batch):
-        logger.info(f"\n\nHandler received batch: {batch}\n\n")
-
-
-class LSEHandler(ResultHandler):
-    """
-    Handler to use the Label Studio SDK to load a batch of results back into a Label Studio project
-    """
-    model_config = ConfigDict(arbitrary_types_allowed=True)  # for @computed_field
-
-    api_key: str
-    url: str
-    job_id: str
-
-    @computed_field
-    def client(self) -> Client:
-        return Client(
-            api_key=self.api_key,
-            url=self.url,
-        )
-
-    @model_validator(mode="after")
-    def ready(self):
-        # Need this to make POST requests using the SDK client
-        self.client.headers.update(
-            {
-                'accept': 'application/json',
-                'Content-Type': 'application/json',
-            }
-        )
-
-        self.client.check_connection()
-
-        return self
-
-    def __call__(self, batch):
-        logger.info(f"\n\nHandler received batch: {batch}\n\n")
-        self.client.make_request(
-            "POST",
-            "/api/model-run/batch-predictions",
-            data=json.dumps(
-                {
-                    'job_id': self.job_id,
-                    'results': batch,
-                }
-            ),
-        )
-
-
-# class ResultHandler(Enum):
-    # DUMMY = dummy_handler
-    # LSE = LSEHandler
 
 
 def get_input_topic(job_id: str):

--- a/server/utils.py
+++ b/server/utils.py
@@ -3,9 +3,11 @@ import json
 
 # from enum import Enum
 from abc import abstractmethod
-from pydantic import BaseModel, computed_field, ConfigDict, model_validator
+from pydantic import BaseModel, computed_field, ConfigDict, model_validator, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import List, Union
+
+from adala.utils.registry import BaseModelInRegistry
 
 from label_studio_sdk import Client
 
@@ -26,7 +28,7 @@ class Settings(BaseSettings):
     )
 
 
-class ResultHandler(BaseModel):
+class ResultHandler(BaseModelInRegistry):
 
     @abstractmethod
     def __call__(self, batch):

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,4 +1,3 @@
-# from enum import Enum
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import List, Union
 from pathlib import Path


### PR DESCRIPTION
- add Label Studio SDK as a dependency (should be an optional dependency for the server only, but there's no clean way to do this in poetry)
- switch ResultHandlers from an enum whitelist of functions to a registry of Pydantic models, same implementation as Environment/Skill/Runtime
- add LSEHandler that pushes predictions to an LS project using an LS SDK Client
- change celery worker functions to use pickle serialization, removing manual step of de/serializing objects on each worker call from an API endpoint
- change utils and handlers import paths to be usable from both main app and celery workers
- make AsyncKafkaEnvironment instantiable as prep for post-streaming refactoring