### PR TITLE
Fix unpickleable fields due to openai client

### DIFF
--- a/adala/runtimes/_openai.py
+++ b/adala/runtimes/_openai.py
@@ -7,11 +7,9 @@ from rich import print
 from typing import Optional, Dict, Any, List
 from openai import OpenAI, NotFoundError
 from pydantic import (
-    model_validator,
-    field_validator,
-    ValidationInfo,
     Field,
     computed_field,
+    ConfigDict
 )
 from .base import Runtime, AsyncRuntime
 from adala.utils.logs import print_error
@@ -162,8 +160,7 @@ class OpenAIChatRuntime(Runtime):
         max_tokens: Maximum number of tokens to generate. Defaults to 1000.
     """
 
-    class Config:
-        arbitrary_types_allowed = True  # for @computed_field
+    model_config = ConfigDict(arbitrary_types_allowed=True)  # for @computed_field
 
     openai_model: str = Field(alias="model")
     openai_api_key: Optional[str] = Field(

--- a/adala/runtimes/_openai.py
+++ b/adala/runtimes/_openai.py
@@ -6,7 +6,13 @@ from rich import print
 
 from typing import Optional, Dict, Any, List
 from openai import OpenAI, NotFoundError
-from pydantic import model_validator, field_validator, ValidationInfo, Field, computed_field
+from pydantic import (
+    model_validator,
+    field_validator,
+    ValidationInfo,
+    Field,
+    computed_field,
+)
 from .base import Runtime, AsyncRuntime
 from adala.utils.logs import print_error
 from adala.utils.internal_data import InternalDataFrame, InternalSeries
@@ -155,6 +161,7 @@ class OpenAIChatRuntime(Runtime):
         openai_api_key: OpenAI API key. If not provided, will be taken from OPENAI_API_KEY environment variable.
         max_tokens: Maximum number of tokens to generate. Defaults to 1000.
     """
+
     class Config:
         arbitrary_types_allowed = True  # for @computed_field
 

--- a/adala/runtimes/_openai.py
+++ b/adala/runtimes/_openai.py
@@ -6,7 +6,7 @@ from rich import print
 
 from typing import Optional, Dict, Any, List
 from openai import OpenAI, NotFoundError
-from pydantic import model_validator, field_validator, ValidationInfo, Field
+from pydantic import model_validator, field_validator, ValidationInfo, Field, computed_field
 from .base import Runtime, AsyncRuntime
 from adala.utils.logs import print_error
 from adala.utils.internal_data import InternalDataFrame, InternalSeries
@@ -155,6 +155,8 @@ class OpenAIChatRuntime(Runtime):
         openai_api_key: OpenAI API key. If not provided, will be taken from OPENAI_API_KEY environment variable.
         max_tokens: Maximum number of tokens to generate. Defaults to 1000.
     """
+    class Config:
+        arbitrary_types_allowed = True  # for @computed_field
 
     openai_model: str = Field(alias="model")
     openai_api_key: Optional[str] = Field(
@@ -163,7 +165,9 @@ class OpenAIChatRuntime(Runtime):
     max_tokens: Optional[int] = 1000
     splitter: Optional[str] = None
 
-    _client: OpenAI = None
+    @computed_field
+    def _client(self) -> OpenAI:
+        return OpenAI(api_key=self.openai_api_key)
 
     def init_runtime(self) -> "Runtime":
         if self._client is None:

--- a/adala/runtimes/_openai.py
+++ b/adala/runtimes/_openai.py
@@ -6,11 +6,7 @@ from rich import print
 
 from typing import Optional, Dict, Any, List
 from openai import OpenAI, NotFoundError
-from pydantic import (
-    Field,
-    computed_field,
-    ConfigDict
-)
+from pydantic import Field, computed_field, ConfigDict
 from .base import Runtime, AsyncRuntime
 from adala.utils.logs import print_error
 from adala.utils.internal_data import InternalDataFrame, InternalSeries
@@ -288,7 +284,6 @@ class AsyncOpenAIChatRuntime(AsyncRuntime):
     timeout: Optional[int] = 10
 
     def init_runtime(self) -> "Runtime":
-
         # check model availability
         try:
             _client = OpenAI(api_key=self.openai_api_key)

--- a/adala/runtimes/_openai.py
+++ b/adala/runtimes/_openai.py
@@ -170,9 +170,6 @@ class OpenAIChatRuntime(Runtime):
         return OpenAI(api_key=self.openai_api_key)
 
     def init_runtime(self) -> "Runtime":
-        if self._client is None:
-            self._client = OpenAI(api_key=self.openai_api_key)
-
         # check model availability
         try:
             self._client.models.retrieve(self.openai_model)
@@ -286,15 +283,12 @@ class AsyncOpenAIChatRuntime(AsyncRuntime):
     concurrent_clients: Optional[int] = 10
     timeout: Optional[int] = 10
 
-    _client: OpenAI = None
-
     def init_runtime(self) -> "Runtime":
-        if self._client is None:
-            self._client = OpenAI(api_key=self.openai_api_key)
 
         # check model availability
         try:
-            self._client.models.retrieve(self.openai_model)
+            _client = OpenAI(api_key=self.openai_api_key)
+            _client.models.retrieve(self.openai_model)
         except NotFoundError:
             raise ValueError(
                 f'Requested model "{self.openai_model}" is not available in your OpenAI account.'


### PR DESCRIPTION
Bugfix - `/submit` requests to the server were failing with the following stack trace:
```
app-1   | ERROR:  Exception in ASGI application
app-1   | Traceback (most recent call last):
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/anyio/streams/memory.py", line 98, in receive
app-1   |   return self.receive_nowait()
app-1   |       ^^^^^^^^^^^^^^^^^^^^^
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/anyio/streams/memory.py", line 93, in receive_nowait
app-1   |   raise WouldBlock
app-1   | anyio.WouldBlock
app-1   | 
app-1   | During handling of the above exception, another exception occurred:
app-1   | 
app-1   | Traceback (most recent call last):
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 78, in call_next
app-1   |   message = await recv_stream.receive()
app-1   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/anyio/streams/memory.py", line 118, in receive
app-1   |   raise EndOfStream
app-1   | anyio.EndOfStream
app-1   | 
app-1   | During handling of the above exception, another exception occurred:
app-1   | 
app-1   | Traceback (most recent call last):
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_impl.py", line 419, in run_asgi
app-1   |   result = await app( # type: ignore[func-returns-value]
app-1   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 84, in __call__
app-1   |   return await self.app(scope, receive, send)
app-1   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/fastapi/applications.py", line 1106, in __call__
app-1   |   await super().__call__(scope, receive, send)
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/starlette/applications.py", line 122, in __call__
app-1   |   await self.middleware_stack(scope, receive, send)
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 184, in __call__
app-1   |   raise exc
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/starlette/middleware/errors.py", line 162, in __call__
app-1   |   await self.app(scope, receive, _send)
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 108, in __call__
app-1   |   response = await self.dispatch_func(request, call_next)
app-1   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app-1   |  File "/usr/src/app/server/log_middleware.py", line 33, in dispatch
app-1   |   response = await call_next(request)
app-1   |         ^^^^^^^^^^^^^^^^^^^^^^^^
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 84, in call_next
app-1   |   raise app_exc
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 70, in coro
app-1   |   await self.app(scope, receive_or_disconnect, send_no_error)
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/starlette/middleware/cors.py", line 91, in __call__
app-1   |   await self.simple_response(scope, receive, send, request_headers=headers)
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/starlette/middleware/cors.py", line 146, in simple_response
app-1   |   await self.app(scope, receive, send)
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
app-1   |   raise exc
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
app-1   |   await self.app(scope, receive, sender)
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 20, in __call__
app-1   |   raise e
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 17, in __call__
app-1   |   await self.app(scope, receive, send)
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/starlette/routing.py", line 718, in __call__
app-1   |   await route.handle(scope, receive, send)
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/starlette/routing.py", line 276, in handle
app-1   |   await self.app(scope, receive, send)
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/starlette/routing.py", line 66, in app
app-1   |   response = await func(request)
app-1   |         ^^^^^^^^^^^^^^^^^^^
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/fastapi/routing.py", line 274, in app
app-1   |   raw_response = await run_endpoint_function(
app-1   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app-1   |  File "/usr/src/app/.venv/lib/python3.11/site-packages/fastapi/routing.py", line 191, in run_endpoint_function
app-1   |   return await dependant.call(**values)
app-1   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app-1   |  File "/usr/src/app/server/app.py", line 109, in submit
app-1   |   serialized_agent = pickle.dumps(request.agent)
app-1   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
app-1   | TypeError: cannot pickle '_thread.RLock' object
```

The root cause is that the `OpenAI` client object in `AsyncOpenAIChatRuntime` and `OpenAIChatRuntime` was attempted to be serialized using `pickle.dumps()`, which is not supported after upgrading the openai client lib: https://github.com/openai/openai-python/issues/837

The solution was to make it a computed field in the sync client, and remove it from the async client as it is unused.