### PR TITLE
fix: DIA-1168: Delete kafka topics on job failure / cancel

### DIFF
--- a/server/utils.py
+++ b/server/utils.py
@@ -65,12 +65,4 @@ def delete_topic(topic_name: str):
         bootstrap_servers=bootstrap_servers, client_id="topic_deleter"
     )
 
-    fs = admin_client.delete_topics(topics=[topic_name])
-    print(fs)
-    # print(fs.__dict__)
-    # for topic, f in fs.items():
-    #     try:
-    #         f.result()
-    #         print("Topic {} deleted".format(topic))
-    #     except Exception as e:
-    #         print("Failed to delete topic {} {}".format(topic_name, e))
+    admin_client.delete_topics(topics=[topic_name])

--- a/server/utils.py
+++ b/server/utils.py
@@ -65,4 +65,12 @@ def delete_topic(topic_name: str):
         bootstrap_servers=bootstrap_servers, client_id="topic_deleter"
     )
 
-    admin_client.delete_topics(topics=[topic_name])
+    fs = admin_client.delete_topics(topics=[topic_name])
+    print(fs)
+    # print(fs.__dict__)
+    # for topic, f in fs.items():
+    #     try:
+    #         f.result()
+    #         print("Topic {} deleted".format(topic))
+    #     except Exception as e:
+    #         print("Failed to delete topic {} {}".format(topic_name, e))


### PR DESCRIPTION
We observed an issue where the list of kafka topics was growing on develop Adala instance, even though we implemented logic to delete them after completing a job. However, we did not handle the case of a job failing, or being canceled. I have added a handler to be run when the parent_streaming_task fails, so that we clean up topics, and also cleaning up topics when we cancel a job.

Also added logic to attempt to stop input/output jobs when the parent task fails. 