### PR TITLE
change consumer timeouts to 1.5sec and task timeout to 6hrs

### DIFF
--- a/server/utils.py
+++ b/server/utils.py
@@ -13,9 +13,9 @@ class Settings(BaseSettings):
 
     kafka_bootstrap_servers: Union[str, List[str]]
     kafka_retention_ms: int = 180000  # 30 minutes
-    kafka_input_consumer_timeout_ms: int = 3000  # 3 seconds
-    kafka_output_consumer_timeout_ms: int = 3000  # 3 seconds
-    task_time_limit_sec: int = 60 * 60 * 24  # 1 day
+    kafka_input_consumer_timeout_ms: int = 1500  # 1.5 seconds
+    kafka_output_consumer_timeout_ms: int = 1500  # 1.5 seconds
+    task_time_limit_sec: int = 60 * 60 * 6  # 6 hours
 
     model_config = SettingsConfigDict(
         # have to use an absolute path here so celery workers can find it


### PR DESCRIPTION
consumer timeouts - reduce time to first record w/ tradeoff of increased change that a long-running record is dropped

(longest running record -> exponential retry backoff w/ max of 1sec)

task timeout - reduce potential number of zombie jobs w/ tradeoff of increased chance of canceling a long-running job

(longest projected job -> 10k records has worst case 10 mins from load test, so 100k records would be <2hrs)