### PR TITLE
fix: DIA-1334: Catch and report pydantic ValidationError

### DIFF
--- a/adala/utils/exceptions.py
+++ b/adala/utils/exceptions.py
@@ -1,0 +1,6 @@
+
+class ConstrainedGenerationError(Exception):
+    def __init__(self):
+        self.message = "The selected provider model could not generate a properly-formatted response"
+
+        super(ConstrainedGenerationError, self).__init__(self.message)


### PR DESCRIPTION
1. Specifying to instructor/tenacity to not retry on pydantic ValidationError 
2. When this case is hit, raising a custom exception to return to LSE - ContrainedGenerationError