### PR TITLE
fix: DIA-1441: RecursionError better traceback logging

### DIFF
--- a/adala/runtimes/_litellm.py
+++ b/adala/runtimes/_litellm.py
@@ -84,7 +84,9 @@ def _format_error_dict(e: Exception) -> dict:
 def _log_llm_exception(e) -> dict:
     dct = _format_error_dict(e)
     base_error = f"Inference error {dct['_adala_message']}"
-    tb = traceback.format_exc()
+    tb = "".join(
+        traceback.format_exception(e)
+    )  # format_exception return list of strings ending in new lines
     logger.error(f"{base_error}\nTraceback:\n{tb}")
     return dct
 


### PR DESCRIPTION
Currently when we are printing the traceback for exceptions caught we were using `traceback.format_exc` which uses `*sys.exc_info()` instead of accepting an exception object itself. For some reason in this flow, this was returning None. Now using `traceback.format_exception()` which DOES take an exception object argument, and will return the traceback as a list of strings. Current just printing it (like `traceback.print_exception()` but might be useful to send back to LSE in the future 