### PR TITLE
fix: DIA-1556: Not getting predictions for all tasks

### DIFF
--- a/adala/environments/kafka.py
+++ b/adala/environments/kafka.py
@@ -55,6 +55,7 @@ class AsyncKafkaEnvironment(AsyncEnvironment):
             self.kafka_input_topic,
             bootstrap_servers=self.kafka_bootstrap_servers,
             value_deserializer=lambda v: json.loads(v.decode("utf-8")),
+            enable_auto_commit=False,
             auto_offset_reset="earliest",
             group_id=self.kafka_input_topic,
         )
@@ -109,6 +110,7 @@ class AsyncKafkaEnvironment(AsyncEnvironment):
         batch = await self.consumer.getmany(
             timeout_ms=self.timeout_ms, max_records=batch_size
         )
+        await self.consumer.commit()
 
         if len(batch) == 0:
             batch_data = []

--- a/adala/environments/kafka.py
+++ b/adala/environments/kafka.py
@@ -56,13 +56,14 @@ class AsyncKafkaEnvironment(AsyncEnvironment):
             bootstrap_servers=self.kafka_bootstrap_servers,
             value_deserializer=lambda v: json.loads(v.decode("utf-8")),
             auto_offset_reset="earliest",
-            group_id="adala-consumer-group",  # TODO: make it configurable based on the environment
+            group_id=self.kafka_input_topic,
         )
         await self.consumer.start()
 
         self.producer = AIOKafkaProducer(
             bootstrap_servers=self.kafka_bootstrap_servers,
             value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+            acks='all'
         )
         await self.producer.start()
 

--- a/adala/environments/kafka.py
+++ b/adala/environments/kafka.py
@@ -55,16 +55,16 @@ class AsyncKafkaEnvironment(AsyncEnvironment):
             self.kafka_input_topic,
             bootstrap_servers=self.kafka_bootstrap_servers,
             value_deserializer=lambda v: json.loads(v.decode("utf-8")),
-            enable_auto_commit=False,
+            enable_auto_commit=False, # True by default which causes messages to be missed when using getmany()
             auto_offset_reset="earliest",
-            group_id=self.kafka_input_topic,
+            group_id=self.kafka_input_topic, # ensuring unique group_id to not mix up offsets between topics
         )
         await self.consumer.start()
 
         self.producer = AIOKafkaProducer(
             bootstrap_servers=self.kafka_bootstrap_servers,
             value_serializer=lambda v: json.dumps(v).encode("utf-8"),
-            acks='all'
+            acks='all' # waits for all replicas to respond that they have written the message
         )
         await self.producer.start()
 

--- a/adala/environments/kafka.py
+++ b/adala/environments/kafka.py
@@ -96,7 +96,7 @@ class AsyncKafkaEnvironment(AsyncEnvironment):
         record_no = 0
         try:
             for record in data:
-                await producer.send_and_wait(topic, value=record)
+                await producer.send(topic, value=record)
                 record_no += 1
                 # print_text(f"Sent message: {record} to {topic=}")
             logger.info(

--- a/server/app.py
+++ b/server/app.py
@@ -190,6 +190,7 @@ async def submit_batch(batch: BatchData):
     producer = AIOKafkaProducer(
         bootstrap_servers=settings.kafka_bootstrap_servers,
         value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+        acks='all'
     )
     await producer.start()
 

--- a/server/app.py
+++ b/server/app.py
@@ -190,7 +190,7 @@ async def submit_batch(batch: BatchData):
     producer = AIOKafkaProducer(
         bootstrap_servers=settings.kafka_bootstrap_servers,
         value_serializer=lambda v: json.dumps(v).encode("utf-8"),
-        acks='all'
+        acks='all' # waits for all replicas to respond that they have written the message
     )
     await producer.start()
 

--- a/server/tasks/stream_inference.py
+++ b/server/tasks/stream_inference.py
@@ -71,7 +71,7 @@ async def run_streaming(
     task_time_limit=settings.task_time_limit_sec,
 )
 def streaming_parent_task(
-    self, agent: Agent, result_handler: ResultHandler, batch_size: int = 10
+    self, agent: Agent, result_handler: ResultHandler, batch_size: int = 50
 ):
     """
     This task is used to launch the two tasks that are doing the real work, so that

--- a/server/tasks/stream_inference.py
+++ b/server/tasks/stream_inference.py
@@ -141,6 +141,7 @@ async def async_process_streaming_output(
                 bootstrap_servers=settings.kafka_bootstrap_servers,
                 value_deserializer=lambda v: json.loads(v.decode("utf-8")),
                 auto_offset_reset="earliest",
+                group_id=output_topic_name,
             )
             await consumer.start()
             logger.info(f"consumer started {output_topic_name=}")

--- a/server/tasks/stream_inference.py
+++ b/server/tasks/stream_inference.py
@@ -158,7 +158,7 @@ async def async_process_streaming_output(
     try:
         while not input_done.is_set():
             data = await consumer.getmany(timeout_ms=timeout_ms, max_records=batch_size)
-            await self.consumer.commit()
+            await consumer.commit()
             for topic_partition, messages in data.items():
                 topic = topic_partition.topic
                 if messages:


### PR DESCRIPTION
acks='all' ensures that all replicas have written the message that is produced 

group_id for consumers is to allow multiple consumers to consume from the same topic. In this case we have a 1-to-1 relationship and each group_id should be unique in order to properly track the offset for each topic

manual offset committing in the consumer seems to have solved the issue. 4 in a row runs with 10k/10k outputs. 

We still need the `time.sleep(0.1)` in the submit_batch endpoint, without it we still hit the same offset issue on the consumer side... unclear why exactly. 
