### PR TITLE
fix: DIA-1489: backwards compatible autorefinement with non-multiskill

### DIFF
--- a/adala/skills/collection/prompt_improvement.py
+++ b/adala/skills/collection/prompt_improvement.py
@@ -70,6 +70,9 @@ class PromptImprovementSkill(AnalysisSkill):
         else:
             model_json_schema = self.skill_to_improve.response_model.model_json_schema()
 
+        # TODO: can remove this when only LabelStudioSkill is supported
+        label_config = self.skill_to_improve.getattr('label_config', '<View>Not available</View>')
+
         input_variables = self.input_variables
         output_variables = list(model_json_schema['properties'].keys())
         input_json_template = get_json_template(input_variables)
@@ -84,7 +87,7 @@ class PromptImprovementSkill(AnalysisSkill):
 
 ## Current Labeling Config:
 ```xml
-{self.skill_to_improve.label_config}
+{label_config}
 ```
 
 ## Input variables:

--- a/adala/skills/collection/prompt_improvement.py
+++ b/adala/skills/collection/prompt_improvement.py
@@ -71,7 +71,7 @@ class PromptImprovementSkill(AnalysisSkill):
             model_json_schema = self.skill_to_improve.response_model.model_json_schema()
 
         # TODO: can remove this when only LabelStudioSkill is supported
-        label_config = self.skill_to_improve.getattr('label_config', '<View>Not available</View>')
+        label_config = getattr(self.skill_to_improve, 'label_config', '<View>Not available</View>')
 
         input_variables = self.input_variables
         output_variables = list(model_json_schema['properties'].keys())


### PR DESCRIPTION
fall back to a default label config