### PR TITLE
fix: DIA-1637: Check object tag compatibility for NER tags

### DIFF
--- a/adala/skills/collection/label_studio.py
+++ b/adala/skills/collection/label_studio.py
@@ -54,7 +54,10 @@ class LabelStudioSkill(TransformSkill):
             tag = self.label_interface.get_control(tag_name)
             if tag.tag.lower() in {"labels", "hypertextlabels"}:
                 if self.allowed_object_tags:
-                    if all(object_tag.tag in self.allowed_object_tags for object_tag in tag.objects):
+                    if all(
+                        object_tag.tag in self.allowed_object_tags
+                        for object_tag in tag.objects
+                    ):
                         tags.append(tag)
                 else:
                     tags.append(tag)

--- a/adala/skills/collection/label_studio.py
+++ b/adala/skills/collection/label_studio.py
@@ -52,10 +52,12 @@ class LabelStudioSkill(TransformSkill):
         tags = []
         for tag_name in control_tag_names:
             tag = self.label_interface.get_control(tag_name)
-            if tag.tag.lower() in {"labels", "hypertextlabels"} and any(
-                object_tag.tag in self.allowed_object_tags for object_tag in tag.objects
-            ):
-                tags.append(tag)
+            if tag.tag.lower() in {"labels", "hypertextlabels"}:
+                if self.allowed_object_tags:
+                    if all(object_tag.tag in self.allowed_object_tags for object_tag in tag.objects):
+                        tags.append(tag)
+                else:
+                    tags.append(tag)
         return tags
 
     @cached_property

--- a/adala/skills/collection/label_studio.py
+++ b/adala/skills/collection/label_studio.py
@@ -36,7 +36,7 @@ class LabelStudioSkill(TransformSkill):
     label_config: str = "<View></View>"
     allowed_control_tags: Optional[list[str]] = None
     allowed_object_tags: Optional[list[str]] = None
-    
+
     # TODO: implement postprocessing to verify Taxonomy
 
     @cached_property
@@ -52,7 +52,9 @@ class LabelStudioSkill(TransformSkill):
         tags = []
         for tag_name in control_tag_names:
             tag = self.label_interface.get_control(tag_name)
-            if tag.tag.lower() in {"labels", "hypertextlabels"}:
+            if tag.tag.lower() in {"labels", "hypertextlabels"} and any(
+                object_tag.tag in self.allowed_object_tags for object_tag in tag.objects
+            ):
                 tags.append(tag)
         return tags
 
@@ -68,14 +70,13 @@ class LabelStudioSkill(TransformSkill):
             if tag.tag.lower() == "image":
                 tags.append(tag)
         return tags
-            
-                
+
     def __getstate__(self):
         """Exclude cached properties when pickling - otherwise the 'Agent' can not be serialized in celery"""
         state = deepcopy(super().__getstate__())
         # Remove cached_property values
-        for key in ['label_interface', 'ner_tags', 'image_tags']:
-            state['__dict__'].pop(key, None)
+        for key in ["label_interface", "ner_tags", "image_tags"]:
+            state["__dict__"].pop(key, None)
         return state
 
     @model_validator(mode="after")

--- a/server/app.py
+++ b/server/app.py
@@ -165,7 +165,7 @@ async def submit_streaming(request: SubmitStreamingRequest):
     """
 
     task = streaming_parent_task
-    
+
     result = task.apply_async(
         kwargs={"agent": request.agent, "result_handler": request.result_handler}
     )

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -148,11 +148,11 @@ def test_agent_is_pickleable():
             "timeout_ms": 1000,
         },
         "skills": [
-        {
-            "name": "label_studio_skill",
-            "type": "LabelStudioSkill",
-            "input_template": "Classify sentiment of the input text: {input}",
-            "label_config": """
+            {
+                "name": "label_studio_skill",
+                "type": "LabelStudioSkill",
+                "input_template": "Classify sentiment of the input text: {input}",
+                "label_config": """
             <View>
                 <Text name="text" value="$text" />
                 <Choices name="output" toName="text">
@@ -161,7 +161,7 @@ def test_agent_is_pickleable():
                     <Choice value="neutral" />
                 </Choices>
             </View>
-            """
+            """,
             }
         ],
     }

--- a/tests/test_stream_inference.py
+++ b/tests/test_stream_inference.py
@@ -42,7 +42,7 @@ TEST_AGENT = {
                     <Choice value="neutral" />
                 </Choices>
             </View>
-            """
+            """,
         }
     ],
 }
@@ -168,11 +168,15 @@ async def test_run_streaming(
     )
 
     # Verify that producer is called with the correct amount of send_and_wait calls and data
-    assert mock_kafka_producer.send_and_wait.call_count == 1, f"Expected 1 call but got {mock_kafka_producer.send_and_wait.call_count}"
+    assert (
+        mock_kafka_producer.send_and_wait.call_count == 1
+    ), f"Expected 1 call but got {mock_kafka_producer.send_and_wait.call_count}"
     try:
         mock_kafka_producer.send_and_wait.assert_any_call(
             "output_topic", value=TEST_OUTPUT_DATA
         )
     except AssertionError as e:
         actual_calls = mock_kafka_producer.send_and_wait.call_args_list
-        raise AssertionError(f"Expected call with ('output_topic', value={TEST_OUTPUT_DATA}) but got:\n{actual_calls}") from e
+        raise AssertionError(
+            f"Expected call with ('output_topic', value={TEST_OUTPUT_DATA}) but got:\n{actual_calls}"
+        ) from e


### PR DESCRIPTION
We are filtering in LabelStudioSkill.validate_response_model based on `allowed_control_tags` and `allowed_object_tags` but not overwriting `self.label_config` based on this - only `self.field_schema` 

Now checking to make sure any `Labels` tag points to a compatible object tag 