### PR TITLE
fix: DIA-1739: increase kafka input topic timeout

### DIFF
--- a/server/utils.py
+++ b/server/utils.py
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
 
     kafka_bootstrap_servers: Union[str, List[str]] = "localhost:9093"
     kafka_retention_ms: int = 180000  # 30 minutes
-    kafka_input_consumer_timeout_ms: int = 1500  # 1.5 seconds
+    kafka_input_consumer_timeout_ms: int = 2500  # 2.5 seconds
     kafka_output_consumer_timeout_ms: int = 1500  # 1.5 seconds
     task_time_limit_sec: int = 60 * 60 * 6  # 6 hours
     # https://docs.celeryq.dev/en/v5.4.0/userguide/configuration.html#worker-max-memory-per-child


### PR DESCRIPTION
Increase input topic timeout to allow time for generating presigned urls.

Opting to increase this rather than decrease the batch size more, as a temporary solution.