### PR TITLE
feat: DIA-1886: Add o3-mini OpenAI model

### DIFF
--- a/adala/runtimes/_litellm.py
+++ b/adala/runtimes/_litellm.py
@@ -261,8 +261,8 @@ class LiteLLMChatRuntime(InstructorClientMixin, Runtime):
     """
 
     model: str = "gpt-4o-mini"
-    max_tokens: int = 1000
-    temperature: float = 0.0
+    max_tokens: Optional[int] = 1000
+    temperature: Optional[float] = 0.0
     seed: Optional[int] = 47
 
     model_config = ConfigDict(extra="allow")
@@ -406,8 +406,8 @@ class AsyncLiteLLMChatRuntime(InstructorAsyncClientMixin, AsyncRuntime):
     """
 
     model: str = "gpt-4o-mini"
-    max_tokens: int = 1000
-    temperature: float = 0.0
+    max_tokens: Optional[int] = 1000
+    temperature: Optional[float] = 0.0
     seed: Optional[int] = 47
 
     model_config = ConfigDict(extra="allow")


### PR DESCRIPTION
o3-mini does not support `max_tokens` or `temperature` so making those params optional 