### PR TITLE
fix: DIA-1983: Decouple LLM compute / message parser / LiteLLM interface

### DIFF
--- a/adala/runtimes/_litellm.py
+++ b/adala/runtimes/_litellm.py
@@ -21,6 +21,7 @@ from litellm.exceptions import (
     ContentPolicyViolationError,
     BadRequestError,
     NotFoundError,
+    APIConnectionError,
 )
 from litellm.types.utils import Usage
 import instructor
@@ -33,7 +34,17 @@ from adala.utils.parse import (
     parse_template,
     partial_str_format,
     TemplateChunks,
+    MessageChunkType,
 )
+from adala.utils.llm_utils import (
+    run_instructor_with_payload,
+    run_instructor_with_payloads,
+    arun_instructor_with_payload,
+    arun_instructor_with_payloads,
+    run_instructor_with_messages,
+    arun_instructor_with_messages,
+)
+
 from pydantic import ConfigDict, field_validator, BaseModel
 from pydantic_core import to_jsonable_python
 from rich import print
@@ -62,95 +73,13 @@ RETRY_POLICY = dict(
             ContentPolicyViolationError,
             AuthenticationError,
             BadRequestError,
+            APIConnectionError
         )
     ),
     # should stop earlier on ValidationError and later on other errors, but couldn't figure out how to do that cleanly
     stop=stop_after_attempt(3),
     wait=wait_random_exponential(multiplier=1, max=60),
 )
-
-
-# TODO: consolidate these data models and unify our preprocessing for LLM input into one step RawInputModel -> PreparedInputModel
-class TextMessageChunk(TypedDict):
-    type: Literal["text"]
-    text: str
-
-
-class ImageMessageChunk(TypedDict):
-    type: Literal["image"]
-    image_url: Dict[str, str]
-
-
-MessageChunk = Union[TextMessageChunk, ImageMessageChunk]
-
-Message = Union[str, List[MessageChunk]]
-
-
-def get_messages(
-    # user prompt can be a string or a list of multimodal message chunks
-    user_prompt: Message,
-    system_prompt: Optional[str] = None,
-    instruction_first: bool = True,
-):
-    messages = [{"role": "user", "content": user_prompt}]
-    if system_prompt:
-        if instruction_first:
-            messages.insert(0, {"role": "system", "content": system_prompt})
-        else:
-            messages[0]["content"] += system_prompt
-    return messages
-
-
-def _format_error_dict(e: Exception) -> dict:
-    error_message = type(e).__name__
-    error_details = str(e)
-    # TODO change this format?
-    error_dct = {
-        "_adala_error": True,
-        "_adala_message": error_message,
-        "_adala_details": error_details,
-    }
-    return error_dct
-
-
-def _log_llm_exception(e) -> dict:
-    dct = _format_error_dict(e)
-    base_error = f"Inference error {dct['_adala_message']}"
-    tb = "".join(
-        traceback.format_exception(e)
-    )  # format_exception return list of strings ending in new lines
-    logger.error(f"{base_error}\nTraceback:\n{tb}")
-    return dct
-
-
-def _get_usage_dict(usage: Usage, model: str) -> Dict:
-    data = dict()
-    data["_prompt_tokens"] = usage.prompt_tokens
-
-    # will not exist if there is no completion
-    # sometimes the response will have a CompletionUsage instead of a Usage, which doesn't have a .get() method
-    # data["_completion_tokens"] = usage.get("completion_tokens", 0)
-    try:
-        data["_completion_tokens"] = usage.completion_tokens
-    except AttributeError:
-        data["_completion_tokens"] = 0
-
-    # can't use litellm.completion_cost bc it only takes the most recent completion, and .usage is summed over retries
-    # TODO make sure this is calculated correctly after we turn on caching
-    # litellm will register the cost of an azure model on first successful completion. If there hasn't been a successful completion, the model will not be registered
-    try:
-        prompt_cost, completion_cost = litellm.cost_per_token(
-            model, data["_prompt_tokens"], data["_completion_tokens"]
-        )
-        data["_prompt_cost_usd"] = prompt_cost
-        data["_completion_cost_usd"] = completion_cost
-        data["_total_cost_usd"] = prompt_cost + completion_cost
-    except:
-        logger.error(f"Failed to get cost for model {model}")
-        data["_prompt_cost_usd"] = None
-        data["_completion_cost_usd"] = None
-        data["_total_cost_usd"] = None
-    return data
 
 
 def normalize_litellm_model_and_provider(model_name: str, provider: str):
@@ -187,56 +116,6 @@ class InstructorClientMixin(BaseModel):
 class InstructorAsyncClientMixin(InstructorClientMixin):
     def _from_litellm(self, **kwargs):
         return instructor.from_litellm(litellm.acompletion, **kwargs)
-
-
-def handle_llm_exception(
-    e: Exception, messages: List[Dict[str, str]], model: str, retries
-) -> tuple[Dict, Usage]:
-    """Handle exceptions from LLM calls and return standardized error dict and usage stats.
-
-    Args:
-        e: The caught exception
-        messages: The messages that were sent to the LLM
-        model: The model name
-        retries: The retry policy object
-
-    Returns:
-        Tuple of (error_dict, usage_stats)
-    """
-
-    if isinstance(e, IncompleteOutputException):
-        usage = e.total_usage
-    elif isinstance(e, InstructorRetryException):
-        usage = e.total_usage
-        # get root cause error from retries
-        e = e.__cause__.last_attempt.exception()
-    else:
-        # Approximate usage for other errors
-        # usage = e.total_usage
-        # not available here, so have to approximate by hand, assuming the same error occurred each time
-        n_attempts = retries.stop.max_attempt_number
-        # Note that the default model used in token_counter is gpt-3.5-turbo as of now - if model passed in
-        # does not match a mapped model, falls back to default
-        prompt_tokens = n_attempts * litellm.token_counter(
-            model=model, messages=messages[:-1]
-        )  # response is appended as the last message
-        # TODO a pydantic validation error may be appended as the last message, don't know how to get the raw response in this case
-        usage = Usage(
-            prompt_tokens=prompt_tokens,
-            completion_tokens=0,
-            total_tokens=prompt_tokens,
-        )
-        # Catch case where the model does not return a properly formatted out
-        # AttributeError is an instructor bug: https://github.com/instructor-ai/instructor/pull/1103
-        # > AttributeError: 'NoneType' object has no attribute '_raw_response'
-        if type(e).__name__ in {"ValidationError", "AttributeError"}:
-            logger.error(f"Converting error to ConstrainedGenerationError: {str(e)}")
-            logger.debug(f"Traceback:\n{traceback.format_exc()}")
-            e = ConstrainedGenerationError()
-
-        # the only other instructor error that would be thrown is IncompleteOutputException due to max_tokens reached
-
-    return _log_llm_exception(e), usage
 
 
 class LiteLLMChatRuntime(InstructorClientMixin, Runtime):
@@ -347,41 +226,21 @@ class LiteLLMChatRuntime(InstructorClientMixin, Runtime):
                 "You must explicitly specify the `response_model` in runtime."
             )
 
-        messages = get_messages(
-            partial_str_format(input_template, **record, **extra_fields),
-            instructions_template,
-            instructions_first,
-        )
-
         retries = Retrying(**RETRY_POLICY)
-
-        try:
-            # returns a pydantic model named Output
-            response, completion = self.client.chat.completions.create_with_completion(
-                messages=messages,
-                response_model=response_model,
-                model=self.model,
-                max_tokens=self.max_tokens,
-                temperature=self.temperature,
-                seed=self.seed,
-                max_retries=retries,
-                # extra inference params passed to this runtime
-                **self.model_extra,
-            )
-            usage = completion.usage
-            dct = to_jsonable_python(response)
-            # With successful completions we can get canonical model name
-            usage_model = completion.model
-
-        except Exception as e:
-            dct, usage = handle_llm_exception(e, messages, self.model, retries)
-            # With exceptions we dont have access to completion.model
-            usage_model = self.model
-
-        # Add usage data to the response (e.g. token counts, cost)
-        dct.update(_get_usage_dict(usage, model=usage_model))
-
-        return dct
+        
+        return run_instructor_with_payload(
+            client=self.client,
+            payload=record,
+            user_prompt_template=input_template,
+            response_model=response_model,
+            model=self.model,
+            max_tokens=self.max_tokens,
+            temperature=self.temperature,
+            seed=self.seed,
+            retries=retries,
+            extra_fields=extra_fields,
+            **self.model_extra,
+        )
 
 
 class AsyncLiteLLMChatRuntime(InstructorAsyncClientMixin, AsyncRuntime):
@@ -466,59 +325,25 @@ class AsyncLiteLLMChatRuntime(InstructorAsyncClientMixin, AsyncRuntime):
             raise ValueError(
                 "You must explicitly specify the `response_model` in runtime."
             )
-
-        extra_fields = extra_fields or {}
-        user_prompts = batch.apply(
-            # TODO: remove "extra_fields" to avoid name collisions
-            lambda row: partial_str_format(input_template, **row, **extra_fields),
-            axis=1,
-        ).tolist()
-
+        
+        # convert batch to list of payloads
+        payloads = batch.to_dict(orient="records")
         retries = AsyncRetrying(**RETRY_POLICY)
-
-        tasks = [
-            asyncio.ensure_future(
-                self.client.chat.completions.create_with_completion(
-                    messages=get_messages(
-                        user_prompt,
-                        instructions_template,
-                        instructions_first,
-                    ),
-                    response_model=response_model,
-                    model=self.model,
-                    max_tokens=self.max_tokens,
-                    temperature=self.temperature,
-                    seed=self.seed,
-                    max_retries=retries,
-                    # extra inference params passed to this runtime
-                    **self.model_extra,
-                )
-            )
-            for user_prompt in user_prompts
-        ]
-        responses = await asyncio.gather(*tasks, return_exceptions=True)
-
-        # convert list of LLMResponse objects to the dataframe records
-        df_data = []
-        for response in responses:
-            if isinstance(response, Exception):
-                messages = []  # TODO how to get these?
-                dct, usage = handle_llm_exception(
-                    response, messages, self.model, retries
-                )
-                # With exceptions we dont have access to completion.model
-                usage_model = self.model
-            else:
-                resp, completion = response
-                usage = completion.usage
-                dct = to_jsonable_python(resp)
-                # With successful completions we can get canonical model name
-                usage_model = completion.model
-
-            # Add usage data to the response (e.g. token counts, cost)
-            dct.update(_get_usage_dict(usage, model=usage_model))
-
-            df_data.append(dct)
+        extra_fields = extra_fields or {}
+        
+        df_data = await arun_instructor_with_payloads(
+            client=self.client,
+            payloads=payloads,
+            user_prompt_template=input_template,
+            response_model=response_model,
+            model=self.model,
+            max_tokens=self.max_tokens,
+            temperature=self.temperature,
+            seed=self.seed,
+            retries=retries,
+            extra_fields=extra_fields,
+            **self.model_extra,
+        )
 
         output_df = InternalDataFrame(df_data)
         return output_df.set_index(batch.index)
@@ -649,114 +474,6 @@ class AsyncLiteLLMChatRuntime(InstructorAsyncClientMixin, AsyncRuntime):
             )
 
 
-class MessageChunkType(Enum):
-    TEXT = "text"
-    IMAGE_URL = "image_url"
-
-
-def split_message_into_chunks(
-    input_template: str, input_field_types: Dict[str, MessageChunkType], **input_fields
-) -> List[MessageChunk]:
-    """Split a template string with field types into a list of message chunks.
-
-    Takes a template string with placeholders and splits it into chunks based on the field types,
-    preserving the text between placeholders.
-
-    Args:
-        input_template (str): Template string with placeholders, e.g. '{a} is a {b} is an {a}'
-        input_field_types (Dict[str, MessageChunkType]): Dict mapping field names to their types
-        **input_fields: Field values to substitute into template
-
-    Returns:
-        List[Dict[str, str]]: List of message chunks with appropriate type and content.
-            Text chunks have format: {'type': 'text', 'text': str}
-            Image chunks have format: {'type': 'image_url', 'image_url': {'url': str}}
-
-    Example:
-        >>> split_message_into_chunks(
-        ...     '{a} is a {b} is an {a}',
-        ...     {'a': MessageChunkType.TEXT, 'b': MessageChunkType.IMAGE_URL},
-        ...     a='the letter a',
-        ...     b='http://example.com/b.jpg'
-        ... )
-        [
-            {'type': 'text', 'text': 'the letter a is a '},
-            {'type': 'image_url', 'image_url': {'url': 'http://example.com/b.jpg'}},
-            {'type': 'text', 'text': ' is an the letter a'}
-        ]
-    """
-    # Parse template to get field positions and surrounding text
-    parsed = parse_template(input_template)
-
-    def add_to_current_chunk(
-        current_chunk: Optional[MessageChunk], chunk: MessageChunk
-    ) -> MessageChunk:
-        if current_chunk:
-            current_chunk["text"] += chunk["text"]
-            return current_chunk
-        else:
-            return chunk
-
-    # Build chunks by iterating through parsed template parts
-    def build_chunks(
-        parsed: Iterable[TemplateChunks],
-    ) -> Generator[MessageChunk, None, None]:
-        current_chunk: Optional[MessageChunk] = None
-
-        for part in parsed:
-            if part["type"] == "text":
-                current_chunk = add_to_current_chunk(
-                    current_chunk, {"type": "text", "text": part["text"]}
-                )
-            elif part["type"] == "var":
-                field_value = part["text"]
-                try:
-                    field_type = input_field_types[field_value]
-                except KeyError:
-                    raise ValueError(
-                        f"Field {field_value} not found in input_field_types"
-                    )
-                if field_type == MessageChunkType.TEXT:
-                    # try to substitute in variable and add to current chunk
-                    substituted_text = partial_str_format(
-                        f"{{{field_value}}}", **input_fields
-                    )
-                    if substituted_text != field_value:
-                        current_chunk = add_to_current_chunk(
-                            current_chunk, {"type": "text", "text": substituted_text}
-                        )
-                    else:
-                        # be permissive for unfound variables
-                        current_chunk = add_to_current_chunk(
-                            current_chunk,
-                            {"type": "text", "text": f"{{{field_value}}}"},
-                        )
-                elif field_type == MessageChunkType.IMAGE_URL:
-                    substituted_text = partial_str_format(
-                        f"{{{field_value}}}", **input_fields
-                    )
-                    if substituted_text != field_value:
-                        # push current chunk, push image chunk, and start new chunk
-                        if current_chunk:
-                            yield current_chunk
-                        current_chunk = None
-                        yield {
-                            "type": "image_url",
-                            "image_url": {"url": input_fields[field_value]},
-                        }
-                    else:
-                        # be permissive for unfound variables
-                        current_chunk = add_to_current_chunk(
-                            current_chunk,
-                            {"type": "text", "text": f"{{{field_value}}}"},
-                        )
-
-        if current_chunk:
-            yield current_chunk
-
-    return list(build_chunks(parsed))
-
-
 class AsyncLiteLLMVisionRuntime(AsyncLiteLLMChatRuntime):
     """
     Runtime that uses [LiteLLM API](https://litellm.vercel.app/docs) and vision
@@ -794,62 +511,28 @@ class AsyncLiteLLMVisionRuntime(AsyncLiteLLMChatRuntime):
                 "You must explicitly specify the `response_model` in runtime."
             )
 
-        input_field_types = input_field_types or defaultdict(
-            lambda: MessageChunkType.TEXT
-        )
 
         extra_fields = extra_fields or {}
-        user_prompts = batch.apply(
-            # TODO: remove "extra_fields" to avoid name collisions
-            lambda row: split_message_into_chunks(
-                input_template, input_field_types, **row, **extra_fields
-            ),
-            axis=1,
-        ).tolist()
-
-        # rest of this function is the same as AsyncLiteLLMChatRuntime.batch_to_batch
-
+        records = batch.to_dict(orient="records")
         retries = AsyncRetrying(**RETRY_POLICY)
-
-        tasks = [
-            asyncio.ensure_future(
-                self.client.chat.completions.create_with_completion(
-                    messages=get_messages(
-                        user_prompt,
-                        instructions_template,
-                        instructions_first,
-                    ),
-                    response_model=response_model,
-                    model=self.model,
-                    max_tokens=self.max_tokens,
-                    temperature=self.temperature,
-                    seed=self.seed,
-                    max_retries=retries,
-                    # extra inference params passed to this runtime
-                    **self.model_extra,
-                )
-            )
-            for user_prompt in user_prompts
-        ]
-        responses = await asyncio.gather(*tasks, return_exceptions=True)
-
-        # convert list of LLMResponse objects to the dataframe records
-        df_data = []
-        for response in responses:
-            if isinstance(response, Exception):
-                messages = []  # TODO how to get these?
-                dct, usage = handle_llm_exception(
-                    response, messages, self.model, retries
-                )
-            else:
-                resp, completion = response
-                usage = completion.usage
-                dct = to_jsonable_python(resp)
-
-            # Add usage data to the response (e.g. token counts, cost)
-            dct.update(_get_usage_dict(usage, model=self.model))
-
-            df_data.append(dct)
+        
+        df_data = await arun_instructor_with_payloads(
+            client=self.client,
+            payloads=records,
+            user_prompt_template=input_template,
+            response_model=response_model,
+            model=self.model,
+            max_tokens=self.max_tokens,
+            temperature=self.temperature,
+            seed=self.seed,
+            retries=retries,
+            split_into_chunks=True,
+            input_field_types=input_field_types,
+            instructions_first=instructions_first,
+            instructions_template=instructions_template,
+            extra_fields=extra_fields,
+            **self.model_extra,
+        )
 
         output_df = InternalDataFrame(df_data)
         return output_df.set_index(batch.index)

--- a/adala/utils/llm_utils.py
+++ b/adala/utils/llm_utils.py
@@ -1,0 +1,517 @@
+import asyncio
+import logging
+import traceback
+import litellm
+from litellm import token_counter
+from collections import defaultdict
+from typing import Any, Dict, List, Type, Optional
+from pydantic import BaseModel, Field
+from pydantic_core import to_jsonable_python
+from litellm.types.utils import Usage
+from tenacity import Retrying, AsyncRetrying
+from instructor.exceptions import InstructorRetryException, IncompleteOutputException
+from instructor.client import Instructor, AsyncInstructor
+from adala.utils.parse import partial_str_format, split_message_into_chunks, MessageChunkType
+
+logger = logging.getLogger(__name__)
+
+
+class MessagesBuilder(BaseModel):
+    user_prompt_template: str
+    system_prompt: Optional[str] = None
+    instruction_first: bool = True
+    extra_fields: Dict[str, Any] = Field(default_factory=dict)
+    split_into_chunks: bool = False
+    input_field_types: Optional[Dict[str, MessageChunkType]] = Field(default=None)
+
+    def get_messages(self, payload: Dict[str, Any]):
+        if self.split_into_chunks:
+            input_field_types = self.input_field_types or defaultdict(lambda: MessageChunkType.TEXT)
+            user_prompt = split_message_into_chunks(self.user_prompt_template, input_field_types, **payload, **self.extra_fields)
+        else:
+            user_prompt = partial_str_format(self.user_prompt_template, **payload, **self.extra_fields)
+        messages = [{"role": "user", "content": user_prompt}]
+        if self.system_prompt:
+            if self.instruction_first:
+                messages.insert(0, {"role": "system", "content": self.system_prompt})
+            else:
+                messages[0]["content"] += self.system_prompt
+        return messages
+
+
+def _get_usage_dict(usage: Usage, model: str) -> Dict:
+    data = dict()
+    data["_prompt_tokens"] = usage.prompt_tokens
+
+    # will not exist if there is no completion
+    # sometimes the response will have a CompletionUsage instead of a Usage, which doesn't have a .get() method
+    # data["_completion_tokens"] = usage.get("completion_tokens", 0)
+    try:
+        data["_completion_tokens"] = usage.completion_tokens
+    except AttributeError:
+        data["_completion_tokens"] = 0
+
+    # can't use litellm.completion_cost bc it only takes the most recent completion, and .usage is summed over retries
+    # TODO make sure this is calculated correctly after we turn on caching
+    # litellm will register the cost of an azure model on first successful completion. If there hasn't been a successful completion, the model will not be registered
+    try:
+        prompt_cost, completion_cost = litellm.cost_per_token(
+            model, data["_prompt_tokens"], data["_completion_tokens"]
+        )
+        data["_prompt_cost_usd"] = prompt_cost
+        data["_completion_cost_usd"] = completion_cost
+        data["_total_cost_usd"] = prompt_cost + completion_cost
+    except:
+        logger.exception(f"Failed to get cost for model {model}")
+        data["_prompt_cost_usd"] = None
+        data["_completion_cost_usd"] = None
+        data["_total_cost_usd"] = None
+    return data
+
+
+def _format_error_dict(e: Exception) -> dict:
+    error_message = type(e).__name__
+    error_details = str(e)
+    # TODO change this format?
+    error_dct = {
+        "_adala_error": True,
+        "_adala_message": error_message,
+        "_adala_details": error_details,
+    }
+    return error_dct
+
+
+def _log_llm_exception(e) -> dict:
+    dct = _format_error_dict(e)
+    base_error = f"Inference error {dct['_adala_message']}"
+    tb = "".join(
+        traceback.format_exception(e)
+    )  # format_exception return list of strings ending in new lines
+    logger.error(f"{base_error}\nTraceback:\n{tb}")
+    return dct
+
+
+def handle_llm_exception(
+    e: Exception, messages: List[Dict[str, str]], model: str, retries
+) -> tuple[Dict, Usage]:
+    """Handle exceptions from LLM calls and return standardized error dict and usage stats.
+
+    Args:
+        e: The caught exception
+        messages: The messages that were sent to the LLM
+        model: The model name
+        retries: The retry policy object
+
+    Returns:
+        Tuple of (error_dict, usage_stats)
+    """
+    logger.debug(f"LLM Exception: {e}\nTraceback:\n{traceback.format_exc()}")
+    if isinstance(e, IncompleteOutputException):
+        usage = e.total_usage
+    elif isinstance(e, InstructorRetryException):
+        usage = e.total_usage
+        # get root cause error from retries
+        e = e.__cause__.last_attempt.exception()
+    else:
+        # Approximate usage for other errors
+        # usage = e.total_usage
+        # not available here, so have to approximate by hand, assuming the same error occurred each time
+        n_attempts = retries.stop.max_attempt_number
+        # Note that the default model used in token_counter is gpt-3.5-turbo as of now - if model passed in
+        # does not match a mapped model, falls back to default
+        prompt_tokens = n_attempts * litellm.token_counter(
+            model=model, messages=messages[:-1]
+        )  # response is appended as the last message
+        # TODO a pydantic validation error may be appended as the last message, don't know how to get the raw response in this case
+        usage = Usage(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=0,
+            total_tokens=prompt_tokens,
+        )
+        # Catch case where the model does not return a properly formatted out
+        # AttributeError is an instructor bug: https://github.com/instructor-ai/instructor/pull/1103
+        # > AttributeError: 'NoneType' object has no attribute '_raw_response'
+        if type(e).__name__ in {"ValidationError", "AttributeError"}:
+            logger.error(f"Converting error to ConstrainedGenerationError: {str(e)}")
+            e = ConstrainedGenerationError()
+
+        # the only other instructor error that would be thrown is IncompleteOutputException due to max_tokens reached
+
+    return _log_llm_exception(e), usage
+
+
+def run_instructor_with_messages(
+    client: Instructor,
+    messages: List[Dict[str, Any]],
+    response_model: Type[BaseModel],
+    model: str,
+    max_tokens: Optional[int] = None,
+    temperature: Optional[float] = None,
+    seed: Optional[int] = None,
+    retries: Optional[Retrying] = None,
+    **kwargs
+) -> Dict[str, Any]:
+    """
+    Run a completion with an instructor client and handle errors appropriately.
+    
+    Args:
+        client: The instructor client to use
+        messages: The messages to send to the model
+        response_model: The Pydantic model to validate the response against
+        model: The model name to use
+        max_tokens: Maximum tokens to generate
+        temperature: Temperature for sampling
+        seed: Integer seed to reduce nondeterminism
+        retries: Retry policy to use
+        **kwargs: Additional arguments to pass to the completion call
+        
+    Returns:
+        Dict containing the parsed response and usage information
+    """
+    try:
+        # returns a pydantic model and completion info
+        response, completion = client.chat.completions.create_with_completion(
+            messages=messages,
+            response_model=response_model,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            seed=seed,
+            max_retries=retries,
+            **kwargs
+        )
+        usage = completion.usage
+        dct = to_jsonable_python(response)
+        # With successful completions we can get canonical model name
+        usage_model = completion.model
+
+    except Exception as e:
+        dct, usage = handle_llm_exception(e, messages, model, retries)
+        # With exceptions we don't have access to completion.model
+        usage_model = model
+
+    # Add usage data to the response (e.g. token counts, cost)
+    dct.update(_get_usage_dict(usage, model=usage_model))
+
+    return dct
+
+
+async def arun_instructor_with_messages(
+    client: AsyncInstructor,
+    messages: List[Dict[str, Any]],
+    response_model: Type[BaseModel],
+    model: str,
+    max_tokens: Optional[int] = None,
+    temperature: Optional[float] = None,
+    seed: Optional[int] = None,
+    retries: Optional[AsyncRetrying] = None,
+    **kwargs
+) -> Dict[str, Any]:
+    """
+    Run a completion with an instructor client and handle errors appropriately.
+    
+    Args:
+        client: The instructor client to use
+        messages: The messages to send to the model
+        response_model: The Pydantic model to validate the response against
+        model: The model name to use
+        max_tokens: Maximum tokens to generate
+        temperature: Temperature for sampling
+        seed: Integer seed to reduce nondeterminism
+        retries: Retry policy to use
+        **kwargs: Additional arguments to pass to the completion call
+        
+    Returns:
+        Dict containing the parsed response and usage information
+    """
+    try:
+        # returns a pydantic model and completion info
+        response, completion = await client.chat.completions.create_with_completion(
+            messages=messages,
+            response_model=response_model,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            seed=seed,
+            max_retries=retries,
+            **kwargs
+        )
+        usage = completion.usage
+        dct = to_jsonable_python(response)
+        # With successful completions we can get canonical model name
+        usage_model = completion.model
+
+    except Exception as e:
+        dct, usage = handle_llm_exception(e, messages, model, retries)
+        # With exceptions we don't have access to completion.model
+        usage_model = model
+
+    # Add usage data to the response (e.g. token counts, cost)
+    dct.update(_get_usage_dict(usage, model=usage_model))
+
+    return dct
+
+
+def run_instructor_with_payload(
+    client: Instructor,
+    payload: Dict[str, Any],
+    user_prompt_template: str,
+    response_model: Type[BaseModel],
+    model: str,
+    max_tokens: Optional[int] = None,
+    temperature: Optional[float] = None,
+    seed: Optional[int] = None,
+    retries: Optional[Retrying] = None,
+    instructions_template: Optional[str] = None,
+    instructions_first: bool = True,
+    input_field_types: Optional[Dict[str, MessageChunkType]] = None,
+    split_into_chunks: bool = False,
+    extra_fields: Optional[Dict[str, Any]] = None,
+    **kwargs
+) -> Dict[str, Any]:
+    """
+    Run a completion with an instructor client and handle errors appropriately.
+    
+    Args:
+        client: The instructor client to use
+        payload: The data payload to send to the model
+        user_prompt_template: The template to use for the user prompt
+        response_model: The Pydantic model to validate the response against
+        model: The model name to use
+        max_tokens: Maximum tokens to generate
+        temperature: Temperature for sampling
+        seed: Integer seed to reduce nondeterminism
+        retries: Retry policy to use
+        instructions_template: The template to use for the instructions
+        instructions_first: Whether to insert the instructions at the beginning of the message
+        input_field_types: The types of the input fields
+        split_into_chunks: Whether to split the user prompt into chunks
+        extra_fields: Additional fields to send to the model
+        **kwargs: Additional arguments to pass to the completion call
+        
+    Returns:
+        Dict containing the parsed response and usage information
+    """
+    
+    messages_builder = MessagesBuilder(
+        user_prompt_template=user_prompt_template,
+        instructions_template=instructions_template,
+        instructions_first=instructions_first,
+        input_field_types=input_field_types,
+        extra_fields=extra_fields,
+        split_into_chunks=split_into_chunks
+    )
+    
+    messages = messages_builder.get_messages(payload)
+    return run_instructor_with_messages(
+        client,
+        messages,
+        response_model,
+        model,
+        max_tokens,
+        temperature,
+        seed,
+        retries,
+        **kwargs
+    )
+    
+
+
+async def arun_instructor_with_payload(
+    client: AsyncInstructor,
+    payload: Dict[str, Any],
+    user_prompt_template: str,
+    response_model: Type[BaseModel],
+    model: str,
+    max_tokens: Optional[int] = None,
+    temperature: Optional[float] = None,
+    seed: Optional[int] = None,
+    retries: Optional[AsyncRetrying] = None,
+    instructions_template: Optional[str] = None,
+    instructions_first: bool = True,
+    input_field_types: Optional[Dict[str, MessageChunkType]] = None,
+    extra_fields: Optional[Dict[str, Any]] = None,
+    split_into_chunks: bool = False,
+    **kwargs
+) -> Dict[str, Any]:
+    """
+    Run a completion with an instructor client and handle errors appropriately.
+    
+    Args:
+        client: The instructor client to use
+        payload: The data payload to send to the model
+        user_prompt_template: The template to use for the user prompt
+        response_model: The Pydantic model to validate the response against
+        model: The model name to use
+        max_tokens: Maximum tokens to generate
+        temperature: Temperature for sampling
+        seed: Integer seed to reduce nondeterminism
+        retries: Retry policy to use
+        instructions_template: The template to use for the instructions
+        instructions_first: Whether to insert the instructions at the beginning of the message
+        input_field_types: The types of the input fields
+        extra_fields: Additional fields to send to the model
+        split_into_chunks: Whether to split the user prompt into chunks
+        **kwargs: Additional arguments to pass to the completion call
+        
+    Returns:
+        Dict containing the parsed response and usage information
+    """
+    
+    messages_builder = MessagesBuilder(
+        user_prompt_template=user_prompt_template,
+        instructions_template=instructions_template,
+        instructions_first=instructions_first,
+        input_field_types=input_field_types,
+        extra_fields=extra_fields,
+        split_into_chunks=split_into_chunks
+    )
+    
+    messages = messages_builder.get_messages(payload)
+    return await arun_instructor_with_messages(
+        client,
+        messages,
+        response_model,
+        model,
+        max_tokens,
+        temperature,
+        seed,
+        retries,
+        **kwargs
+    )
+    
+def run_instructor_with_payloads(
+    client: Instructor,
+    payloads: List[Dict[str, Any]],
+    user_prompt_template: str,
+    response_model: Type[BaseModel],
+    model: str,
+    max_tokens: int,
+    temperature: float,
+    seed: Optional[int],
+    retries: Retrying,
+    instructions_template: Optional[str] = None,
+    instructions_first: bool = True,
+    input_field_types: Optional[Dict[str, MessageChunkType]] = None,
+    split_into_chunks: bool = False,
+    extra_fields: Optional[Dict[str, Any]] = None,
+    **kwargs
+) -> List[Dict[str, Any]]:
+    """
+    Run completions with an instructor client for multiple payloads and handle errors appropriately.
+    Synchronous version of arun_instructor_completions.
+    
+    Args:
+        client: The instructor client to use
+        payloads: List of data payloads to send to the model
+        user_prompt_template: The template to use for the user prompt
+        response_model: The Pydantic model to validate the responses against
+        model: The model name to use
+        max_tokens: Maximum tokens to generate
+        temperature: Temperature for sampling
+        seed: Integer seed to reduce nondeterminism
+        retries: Retry policy to use
+        instructions_template: The template to use for the instructions
+        instructions_first: Whether to insert the instructions at the beginning of the message
+        input_field_types: The types of the input fields
+        split_into_chunks: Whether to split the user prompt into chunks
+        extra_fields: Additional fields to send to the model
+        **kwargs: Additional arguments to pass to the completion calls
+        
+    Returns:
+        List of dicts containing the parsed responses and usage information
+    """
+    messages_builder = MessagesBuilder(
+        user_prompt_template=user_prompt_template,
+        system_prompt=instructions_template,
+        instruction_first=instructions_first,
+        input_field_types=input_field_types,
+        extra_fields=extra_fields,
+        split_into_chunks=split_into_chunks
+    )
+    
+    results = []
+    for payload in payloads:
+        messages = messages_builder.get_messages(payload)
+        result = run_instructor_with_messages(
+            client,
+            messages,
+            response_model,
+            model,
+            max_tokens,
+            temperature,
+            seed,
+            retries,
+            **kwargs
+        )
+        results.append(result)
+    
+    return results
+
+    
+async def arun_instructor_with_payloads(
+    client: AsyncInstructor,
+    payloads: List[Dict[str, Any]],
+    user_prompt_template: str,
+    response_model: Type[BaseModel],
+    model: str,
+    max_tokens: Optional[int] = None,
+    temperature: Optional[float] = None,
+    seed: Optional[int] = None,
+    retries: Optional[AsyncRetrying] = None,
+    instructions_template: Optional[str] = None,
+    instructions_first: bool = True,
+    input_field_types: Optional[Dict[str, MessageChunkType]] = None,
+    split_into_chunks: bool = False,
+    extra_fields: Optional[Dict[str, Any]] = None,
+    **kwargs
+) -> List[Dict[str, Any]]:
+    """
+    Run completions with an instructor client for multiple payloads and handle errors appropriately.
+    
+    Args:
+        client: The instructor client to use
+        payloads: List of data payloads to send to the model
+        user_prompt_template: The template to use for the user prompt
+        response_model: The Pydantic model to validate the responses against
+        model: The model name to use
+        max_tokens: Maximum tokens to generate
+        temperature: Temperature for sampling
+        seed: Integer seed to reduce nondeterminism
+        retries: Retry policy to use
+        instructions_template: The template to use for the instructions
+        instructions_first: Whether to insert the instructions at the beginning of the message
+        input_field_types: The types of the input fields
+        split_into_chunks: Whether to split the user prompt into chunks
+        extra_fields: Additional fields to send to the model
+        **kwargs: Additional arguments to pass to the completion calls
+        
+    Returns:
+        List of dicts containing the parsed responses and usage information
+    """
+    
+    messages_builder = MessagesBuilder(
+        user_prompt_template=user_prompt_template,
+        system_prompt=instructions_template,
+        instruction_first=instructions_first,
+        input_field_types=input_field_types,
+        extra_fields=extra_fields,
+        split_into_chunks=split_into_chunks
+    )
+    
+    tasks = [
+        arun_instructor_with_messages(
+            client,
+            messages_builder.get_messages(payload),
+            response_model,
+            model,
+            max_tokens,
+            temperature,
+            seed,
+            retries,
+            **kwargs
+        )
+        for payload in payloads
+    ]
+    
+    return await asyncio.gather(*tasks)

--- a/adala/utils/parse.py
+++ b/adala/utils/parse.py
@@ -2,7 +2,8 @@ import re
 import string
 import logging
 from string import Formatter
-from typing import List, TypedDict
+from typing import List, TypedDict, Dict, Optional, Union, Literal, Iterable, Generator
+from enum import Enum
 
 logger = logging.getLogger(__name__)
 
@@ -168,3 +169,127 @@ def parse_template(string, include_texts=True) -> List[TemplateChunks]:
         )
 
     return chunks
+
+
+# TODO: consolidate these data models and unify our preprocessing for LLM input into one step RawInputModel -> PreparedInputModel
+class TextMessageChunk(TypedDict):
+    type: Literal["text"]
+    text: str
+
+
+class ImageMessageChunk(TypedDict):
+    type: Literal["image"]
+    image_url: Dict[str, str]
+
+
+MessageChunk = Union[TextMessageChunk, ImageMessageChunk]
+
+Message = Union[str, List[MessageChunk]]
+
+
+class MessageChunkType(Enum):
+    TEXT = "text"
+    IMAGE_URL = "image_url"
+
+
+def split_message_into_chunks(
+    input_template: str, input_field_types: Dict[str, MessageChunkType], **input_fields
+) -> List[MessageChunk]:
+    """Split a template string with field types into a list of message chunks.
+
+    Takes a template string with placeholders and splits it into chunks based on the field types,
+    preserving the text between placeholders.
+
+    Args:
+        input_template (str): Template string with placeholders, e.g. '{a} is a {b} is an {a}'
+        input_field_types (Dict[str, MessageChunkType]): Dict mapping field names to their types
+        **input_fields: Field values to substitute into template
+
+    Returns:
+        List[Dict[str, str]]: List of message chunks with appropriate type and content.
+            Text chunks have format: {'type': 'text', 'text': str}
+            Image chunks have format: {'type': 'image_url', 'image_url': {'url': str}}
+
+    Example:
+        >>> split_message_into_chunks(
+        ...     '{a} is a {b} is an {a}',
+        ...     {'a': MessageChunkType.TEXT, 'b': MessageChunkType.IMAGE_URL},
+        ...     a='the letter a',
+        ...     b='http://example.com/b.jpg'
+        ... )
+        [
+            {'type': 'text', 'text': 'the letter a is a '},
+            {'type': 'image_url', 'image_url': {'url': 'http://example.com/b.jpg'}},
+            {'type': 'text', 'text': ' is an the letter a'}
+        ]
+    """
+    # Parse template to get field positions and surrounding text
+    parsed = parse_template(input_template)
+
+    def add_to_current_chunk(
+        current_chunk: Optional[MessageChunk], chunk: MessageChunk
+    ) -> MessageChunk:
+        if current_chunk:
+            current_chunk["text"] += chunk["text"]
+            return current_chunk
+        else:
+            return chunk
+
+    # Build chunks by iterating through parsed template parts
+    def build_chunks(
+        parsed: Iterable[TemplateChunks],
+    ) -> Generator[MessageChunk, None, None]:
+        current_chunk: Optional[MessageChunk] = None
+
+        for part in parsed:
+            if part["type"] == "text":
+                current_chunk = add_to_current_chunk(
+                    current_chunk, {"type": "text", "text": part["text"]}
+                )
+            elif part["type"] == "var":
+                field_value = part["text"]
+                try:
+                    field_type = input_field_types[field_value]
+                except KeyError:
+                    raise ValueError(
+                        f"Field {field_value} not found in input_field_types. Found fields: {input_field_types}"
+                    )
+                if field_type == MessageChunkType.TEXT:
+                    # try to substitute in variable and add to current chunk
+                    substituted_text = partial_str_format(
+                        f"{{{field_value}}}", **input_fields
+                    )
+                    if substituted_text != field_value:
+                        current_chunk = add_to_current_chunk(
+                            current_chunk, {"type": "text", "text": substituted_text}
+                        )
+                    else:
+                        # be permissive for unfound variables
+                        current_chunk = add_to_current_chunk(
+                            current_chunk,
+                            {"type": "text", "text": f"{{{field_value}}}"},
+                        )
+                elif field_type == MessageChunkType.IMAGE_URL:
+                    substituted_text = partial_str_format(
+                        f"{{{field_value}}}", **input_fields
+                    )
+                    if substituted_text != field_value:
+                        # push current chunk, push image chunk, and start new chunk
+                        if current_chunk:
+                            yield current_chunk
+                        current_chunk = None
+                        yield {
+                            "type": "image_url",
+                            "image_url": {"url": input_fields[field_value]},
+                        }
+                    else:
+                        # be permissive for unfound variables
+                        current_chunk = add_to_current_chunk(
+                            current_chunk,
+                            {"type": "text", "text": f"{{{field_value}}}"},
+                        )
+
+        if current_chunk:
+            yield current_chunk
+
+    return list(build_chunks(parsed))

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -7,7 +7,7 @@ from adala.runtimes import (
     AsyncLiteLLMChatRuntime,
     AsyncLiteLLMVisionRuntime,
 )
-from adala.runtimes._litellm import split_message_into_chunks, MessageChunkType
+from adala.utils.parse import split_message_into_chunks, MessageChunkType
 
 
 @pytest.mark.vcr
@@ -217,6 +217,7 @@ def test_vision_runtime():
             }
         ]
     )
+
     pd.testing.assert_frame_equal(result[["name", "age"]], expected_result)
 
     # assert all other columns (costs) are nonzero


### PR DESCRIPTION
Refactor to facilitate future inference customization:

_litellm.py:

contains interface and wrappers for LiteLLM Adala-specific runtime

llm_utils.py

contains LLM inference (for instructor client as of now)

parse.py:

contains input template and prompt parsers to messages 