### PR TITLE
fix: UTC-241: Increase docker build timeout

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   docker_build_and_push:
     name: "Docker image"
-    timeout-minutes: 15
+    timeout-minutes: 25
     runs-on: ubuntu-latest
     outputs:
       image_version: ${{ steps.version.outputs.image_version }}


### PR DESCRIPTION
All docker builds have been failing in Adala due to this. Not sure why build time has increased yet, but to unblock for now increasing timeout