### PR TITLE
feat: BROS-357: User can select provider/model for <Chat>

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -513,7 +513,6 @@ async def chat_completion(request: Request, chat_request: ChatCompletionRequest)
 
     try:
         runtime_params = _chat_completion_get_runtime_params(request)
-
         if not runtime_params.get("base_url"):
             # Extract base_url from headers if present (due to the OpenAI-compatible API providers)
             runtime_params["base_url"] = request.headers.get("base_url")

--- a/server/app.py
+++ b/server/app.py
@@ -1,14 +1,9 @@
 from enum import Enum
 from typing import Any, Dict, Generic, List, Optional, TypeVar
-import os
+import base64
 import json
-import pandas as pd
 import traceback
-import asyncio
-import signal
-import sys
-from contextlib import asynccontextmanager
-
+import os
 import fastapi
 from fastapi import Request, status
 from fastapi.exceptions import RequestValidationError
@@ -23,6 +18,9 @@ from fastapi.middleware.cors import CORSMiddleware
 import litellm
 from litellm.exceptions import AuthenticationError
 from litellm.utils import check_valid_key, get_valid_models
+from litellm import acompletion
+from openai import OpenAI
+
 from pydantic import BaseModel, SerializeAsAny, field_validator, Field, model_validator
 from redis import Redis
 import time
@@ -421,8 +419,6 @@ class ChatCompletionRequest(BaseModel):
 
     messages: List[Dict]
     model: str
-    base_url: Optional[str] = None
-    api_key: Optional[str] = None
 
 
 class ChatCompletionResponse(BaseModel):
@@ -437,7 +433,70 @@ class ChatCompletionResponse(BaseModel):
     choices: List[Dict]
     usage: Dict
     service_tier: Optional[str] = "default"
+    
+    
+def _chat_completion_get_runtime_params(request: Request) -> Dict:
+    """
+    Get runtime params from the request headers.
+    The minimal `runtime_params` must include `api_key` field.
+    """
+    auth_header = request.headers.get("Authorization") or request.headers.get("authorization")
 
+    if auth_header and auth_header.startswith("Bearer "):
+        credentials_payload = auth_header[7:]
+        try:
+            # Try to decode as base64 and parse as JSON
+            decoded_bytes = base64.b64decode(credentials_payload)
+            decoded_str = decoded_bytes.decode('utf-8')
+            runtime_params = json.loads(decoded_str)
+            
+            if "api_key" not in runtime_params:
+                raise ValueError("api_key missing from credentials")
+                
+            # Remove JWT-related fields as they only needed to check the integrity
+            for field in ("exp", "iat", "iss", "sub"):
+                runtime_params.pop(field, None)
+                
+            return runtime_params
+            
+        except Exception:
+            # If decoding/parsing fails, treat as plain API key
+            return {"api_key": credentials_payload}
+    
+    # Fallback to environment variable
+    if os.getenv("OPENAI_API_KEY"):
+        return {"api_key": os.getenv("OPENAI_API_KEY")}
+    
+    raise HTTPException(
+        status_code=400, 
+        detail="No credentials found in the request headers or environment variables"
+    )
+    
+    
+async def _chat_completion_handle_request(chat_request: ChatCompletionRequest, runtime_params: Dict, provider: str) -> ChatCompletionResponse:
+    if provider == "Custom":
+        # LiteLLM has issues working with Custom OpenAI-compatible API providers
+        client = OpenAI(api_key=runtime_params["api_key"], base_url=runtime_params["base_url"])
+        response = client.chat.completions.create(
+            messages=chat_request.messages,
+            model=chat_request.model,
+        )
+    else:
+        response = await acompletion(
+            messages=chat_request.messages,
+            model=chat_request.model,
+            **runtime_params,
+        )
+    return ChatCompletionResponse(
+        id=response.id,
+        object=response.object,
+        created=response.created,
+        model=response.model,
+        choices=[choice.model_dump() for choice in response.choices],
+        usage=response.usage.model_dump(),
+        service_tier=getattr(response, "service_tier", "default"),
+    )
+    
 
 @app.post("/chat/completions", response_model=ChatCompletionResponse)
 async def chat_completion(request: Request, chat_request: ChatCompletionRequest):
@@ -445,37 +504,20 @@ async def chat_completion(request: Request, chat_request: ChatCompletionRequest)
     Mimics the OpenAI chat completion API.
     https://platform.openai.com/docs/api-reference/chat/create
     """
-    from litellm import acompletion
 
     try:
-        if chat_request.api_key is None:
-            # Extract token from Authorization header or from `api_key` header if present. `api_key` header takes precedence.
-            auth_header = request.headers.get("authorization")
-            api_key_header = request.headers.get("api_key")
-            if api_key_header:
-                chat_request.api_key = api_key_header
-            elif auth_header and auth_header.startswith("Bearer "):
-                chat_request.api_key = auth_header[7:]
+        runtime_params = _chat_completion_get_runtime_params(request)
 
-        if chat_request.base_url is None:
-            # Extract base_url from headers if present.
-            chat_request.base_url = request.headers.get("base_url")
+        if not runtime_params.get("base_url"):
+            # Extract base_url from headers if present (due to the OpenAI-compatible API providers)
+            runtime_params["base_url"] = request.headers.get("base_url")
+            
+        # pop the `model` to ensure it's passed as an input request parameter
+        runtime_params.pop("model", None)
+        provider = runtime_params.pop("provider", None) or "openai"
+        response = await _chat_completion_handle_request(chat_request, runtime_params, provider)
+        return response
 
-        response = await acompletion(
-            messages=chat_request.messages,
-            model=chat_request.model,
-            base_url=chat_request.base_url,
-            api_key=chat_request.api_key,
-        )
-        return ChatCompletionResponse(
-            id=response.id,
-            object=response.object,
-            created=response.created,
-            model=response.model,
-            choices=[choice.model_dump() for choice in response.choices],
-            usage=response.usage.model_dump(),
-            service_tier=getattr(response, "service_tier", "default"),
-        )
 
     except Exception as e:
         logger.error(f"Error in chat completion: {e}")

--- a/server/app.py
+++ b/server/app.py
@@ -483,7 +483,7 @@ async def _chat_completion_handle_request(
         client = AsyncOpenAI(
             api_key=runtime_params["api_key"], base_url=runtime_params["base_url"]
         )
-        response = client.chat.completions.create(
+        response = await client.chat.completions.create(
             messages=chat_request.messages,
             model=chat_request.model,
         )

--- a/tests/cassettes/test_server/test_chat_completion_endpoint_api_client.yaml
+++ b/tests/cassettes/test_server/test_chat_completion_endpoint_api_client.yaml
@@ -22,13 +22,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/61RwU7CQBC99yvWPYOhxQLxYgyQQKIBtFET9TDaod10u1O7C0gI/+62tVDw6h42
-        m3lv5828t3MY45+gQhGCQc2v2autMLYr7wIjZVAZC9QlW8wgN0dudXaNt6UY/C4+8SmDlIUkVMQ2
-        KGWLmRhUwra0YkvKGejEQhdsQhsGOZZ1QyFsb94Ub3TcH97vreMcOUksRFIKUdb0fU3gS6GEjh8Q
-        NKmC9hjM5vyAwjq6oyjL6aNYpd257HT7fXfgdv1Br+tfeb7fd2rpUpSvNER4jwasV3BwhNsWaWYC
-        SlANaVV61atUGs6ewG6NGzIgTyDPa/3pqkdWU8im440w7PIghdkWGwbjl4A3DDInQ9UGOQ0fz0f8
-        Jy33TMz5zaWK6glzLapMIkxtSm3vstNeStBx2ZHnqDNSGqdhwYlvxRpmIxwiuEqP51/h8yRZLLiz
-        d34A3UhFUMACAAA=
+        H4sIAAAAAAAC/61STY/TMBC951cMvnBpq3SbbVkuCJWViACxCxVCAoRmm0li1fGE2GE3qvrfGaeb
+        bgpXfLCseW++3vM+AlBbtJnO0JNTL+GbRAD2/R0wtp6sF2AISbDGxj9xj2c/egvF00NIUilgBRlr
+        W8A9GTMBX6LdQcct5NwAup1Az+C1AwSDTUFy26JFeVSckSSkkm6fe6CHmhpNdktAFXvN1oFUyImM
+        lHBg9I6gbCuUeMYTuGs99N3z1m4DPczAtdcVGtOB7AwNYdaBZxnDaefDVDN4y/cgikhuSabuJ/Wc
+        Yffqu1WjHQ+n94/JkzINGwpr97MP9MNAULm22pWfCB3bQPu8+XijTij+Lt5zUTd8F8SdxrP4cpHE
+        8YvFPJ5fLS+SVXIVDa37pqp1ItQH8iju4ckjJSWq2m94R3bNbe/e8thl5PUZnKwecc8ezRl0uZj8
+        U9W9kZ7ajP/A6HvI8mi078KGm+uvGzUSyJ8NNQgUjXT8e8T/1CtZnTeLHn05WvWFGqePnhRUiUvT
+        i1k8zQ26sq+oGnK1/DhKs8BZp90c08W79XKdWHd9U//81ba3rKJD9AesPA1HUgMAAA==
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -37,11 +38,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 27 Aug 2025 13:30:44 GMT
+      - Mon, 01 Sep 2025 12:05:28 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=658
+      - gfet4t7; dur=550
       Transfer-Encoding:
       - chunked
       Vary:
@@ -68,7 +69,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '156'
+      - '102'
       content-type:
       - application/json
       host:
@@ -79,11 +80,13 @@ interactions:
     uri: http://testserver/chat/completions
   response:
     body:
-      string: '{"id":"chatcmpl-191361c0-1fdb-48d7-af1d-13c38430e62d","object":"chat.completion","created":1756301443,"model":"gemini-2.0-flash","choices":[{"finish_reason":"stop","index":0,"message":{"content":"I
-        am doing well, thank you for asking! How are you today?\n","role":"assistant","tool_calls":null,"function_call":null},"logprobs":-0.03771813586354256}],"usage":{"completion_tokens":16,"prompt_tokens":6,"total_tokens":22,"completion_tokens_details":null,"prompt_tokens_details":{"audio_tokens":null,"cached_tokens":null}},"service_tier":"default"}'
+      string: '{"id":"chatcmpl-146daf9c-aa4a-46f3-a4ac-6f2471902647","object":"chat.completion","created":1756728327,"model":"gemini-2.0-flash","choices":[{"finish_reason":"stop","index":0,"message":{"content":"I
+        am doing well, thank you for asking! As a large language model, I don''t experience
+        emotions or feelings like humans do, but I am functioning optimally and ready
+        to assist you. How can I help you today?\n","role":"assistant","tool_calls":null,"function_call":null},"logprobs":-0.05340083101962475}],"usage":{"completion_tokens":47,"prompt_tokens":6,"total_tokens":53,"completion_tokens_details":null,"prompt_tokens_details":{"audio_tokens":null,"cached_tokens":null}},"service_tier":"default"}'
     headers:
       content-length:
-      - '544'
+      - '690'
       content-type:
       - application/json
     status:

--- a/tests/cassettes/test_server/test_chat_completion_endpoint_api_client.yaml
+++ b/tests/cassettes/test_server/test_chat_completion_endpoint_api_client.yaml
@@ -22,14 +22,13 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/61STY/TMBC951cMvnBpq3SbbVkuCJWViACxCxVCAoRmm0li1fGE2GE3qvrfGaeb
-        bgpXfLCseW++3vM+AlBbtJnO0JNTL+GbRAD2/R0wtp6sF2AISbDGxj9xj2c/egvF00NIUilgBRlr
-        W8A9GTMBX6LdQcct5NwAup1Az+C1AwSDTUFy26JFeVSckSSkkm6fe6CHmhpNdktAFXvN1oFUyImM
-        lHBg9I6gbCuUeMYTuGs99N3z1m4DPczAtdcVGtOB7AwNYdaBZxnDaefDVDN4y/cgikhuSabuJ/Wc
-        Yffqu1WjHQ+n94/JkzINGwpr97MP9MNAULm22pWfCB3bQPu8+XijTij+Lt5zUTd8F8SdxrP4cpHE
-        8YvFPJ5fLS+SVXIVDa37pqp1ItQH8iju4ckjJSWq2m94R3bNbe/e8thl5PUZnKwecc8ezRl0uZj8
-        U9W9kZ7ajP/A6HvI8mi078KGm+uvGzUSyJ8NNQgUjXT8e8T/1CtZnTeLHn05WvWFGqePnhRUiUvT
-        i1k8zQ26sq+oGnK1/DhKs8BZp90c08W79XKdWHd9U//81ba3rKJD9AesPA1HUgMAAA==
+        H4sIAAAAAAAC/61R0U7CMBR931fUPgPZhgP0xRgwkaiR4KImaszVXcZC17u0RSSEf7fdHAx8tQ9N
+        c8/pPfees/EY458gkywBg5qfsxdbYWxT3g4jaVAaC9QlWyxAmT23OpvG21IMfrtPfMwgZwllMmUr
+        FKLFzBzkgq1pyWakGOiFhU7YNa0YKCzrhhJYX7xK3ui43b3fWvs5FAl0IjklKGr6tibwWSYzPZ8i
+        aJKO9hDfT/gOha/0ltJC0Ydbpe13/G6/HwyCbjTodaPTMIr6Xi1divKlhhTv0ID1CnaOcNsiL0xM
+        C5RDWpZe9SqVhrMHcFDjhgyIAygMW3+66pHVzETT8UYYdnkQmVm7DeOr55g3DDIHQ9UGeQ0fj0f8
+        J63gSMz7zaWK6hGVzqpMUsxtSu2w47dnAvS87MgV6oKkxnHiOEYNA7iZPvUKOPPT93gwntDokntb
+        7wexRLZfvwIAAA==
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -38,11 +37,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 01 Sep 2025 12:05:28 GMT
+      - Mon, 01 Sep 2025 14:41:58 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=550
+      - gfet4t7; dur=496
       Transfer-Encoding:
       - chunked
       Vary:
@@ -80,13 +79,11 @@ interactions:
     uri: http://testserver/chat/completions
   response:
     body:
-      string: '{"id":"chatcmpl-146daf9c-aa4a-46f3-a4ac-6f2471902647","object":"chat.completion","created":1756728327,"model":"gemini-2.0-flash","choices":[{"finish_reason":"stop","index":0,"message":{"content":"I
-        am doing well, thank you for asking! As a large language model, I don''t experience
-        emotions or feelings like humans do, but I am functioning optimally and ready
-        to assist you. How can I help you today?\n","role":"assistant","tool_calls":null,"function_call":null},"logprobs":-0.05340083101962475}],"usage":{"completion_tokens":47,"prompt_tokens":6,"total_tokens":53,"completion_tokens_details":null,"prompt_tokens_details":{"audio_tokens":null,"cached_tokens":null}},"service_tier":"default"}'
+      string: '{"id":"chatcmpl-8948fa56-6bc3-48ac-b839-6534449beb70","object":"chat.completion","created":1756737717,"model":"gemini-2.0-flash","choices":[{"finish_reason":"stop","index":0,"message":{"content":"I
+        am doing well, thank you for asking! How are you today?\n","role":"assistant","tool_calls":null,"function_call":null},"logprobs":-0.03771813586354256}],"usage":{"completion_tokens":16,"prompt_tokens":6,"total_tokens":22,"completion_tokens_details":null,"prompt_tokens_details":{"audio_tokens":null,"cached_tokens":null}},"service_tier":"default"}'
     headers:
       content-length:
-      - '690'
+      - '544'
       content-type:
       - application/json
     status:

--- a/tests/cassettes/test_server/test_chat_completion_endpoint_error_handling.yaml
+++ b/tests/cassettes/test_server/test_chat_completion_endpoint_error_handling.yaml
@@ -1,0 +1,338 @@
+interactions:
+- request:
+    body: '{"contents": [{"role": "user", "parts": [{"text": "Hello, how are you?"}]}],
+      "generationConfig": {}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '100'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - litellm/1.65.6
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61R0U6DMBR95ytqnzczmAz0xRg1ccZlixKjUWOucscaSkto2cRl/24B2br5ah+a
+        5p7Te+49Z+0QQj9BxCwGjYqekRdTIWTd3DUmhUahDdCVTDGHQu+47Vlbb0PR+FV/omMCGYklEwlZ
+        Iec9ohcgUlLJksxlQUClBjoiN3JFoMCmrmUM1fmroFbHzfb91tvNUUiOtUgmY+QdfdMR6JwJphb3
+        CEqKmvYQTWd0i8IyuZNJXsiPepX+4HgwDAI3dId+OBr6J57vB04n3YjSUkGCE9RgvIKtI9S0yHId
+        yRTFpSwbr0atiuXsHux2uJYa+B7keb0/XdWV0WTcdtwKwywPnOmq3jC6foqoZZDeG6ozyLF8PBzx
+        n7TcAzHnN5c2qkcsFGszSTAzKfW940F/zkEtmo60QJVLoXAc1xw2Ll2Y4vvt8zcLJuHsdLoMq4uU
+        OhvnBxC84mHAAgAA
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 01 Sep 2025 12:03:20 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=423
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"role": "user", "content": "Hello, how are you?"}], "model":
+      "gemini/gemini-2.0-flash"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '102'
+      content-type:
+      - application/json
+      host:
+      - localhost:30001
+      user-agent:
+      - AsyncOpenAI/Python 1.76.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.76.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.12
+    method: POST
+    uri: http://localhost:30001/chat/completions
+  response:
+    body:
+      string: '{"id":"chatcmpl-26e1bc3a-2b1a-4917-bb03-49e951b15c35","object":"chat.completion","created":1756728200,"model":"gemini-2.0-flash","choices":[{"finish_reason":"stop","index":0,"message":{"content":"I
+        am doing well, thank you for asking! How are you today?\n","role":"assistant","tool_calls":null,"function_call":null},"logprobs":-0.03771813586354256}],"usage":{"completion_tokens":16,"prompt_tokens":6,"total_tokens":22,"completion_tokens_details":null,"prompt_tokens_details":{"audio_tokens":null,"cached_tokens":null}},"service_tier":"default"}'
+    headers:
+      content-length:
+      - '544'
+      content-type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"role": "user", "content": "Hello, how are you?"}], "model":
+      "gemini/gemini-2.0-flash"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      base_url:
+      - http://non.existent.endpoint
+      connection:
+      - keep-alive
+      content-length:
+      - '102'
+      content-type:
+      - application/json
+      host:
+      - localhost:30001
+      user-agent:
+      - AsyncOpenAI/Python 1.76.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.76.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.12
+    method: POST
+    uri: http://localhost:30001/chat/completions
+  response:
+    body:
+      string: '{"detail":"Chat completion failed: litellm.APIConnectionError: Invalid
+        port: ''generateContent''\nTraceback (most recent call last):\n  File \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/httpx/_urlparse.py\",
+        line 364, in normalize_port\n    port_as_int = int(port)\n                  ^^^^^^^^^\nValueError:
+        invalid literal for int() with base 10: ''generateContent''\n\nDuring handling
+        of the above exception, another exception occurred:\n\nTraceback (most recent
+        call last):\n  File \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/litellm/main.py\",
+        line 477, in acompletion\n    response = await init_response\n               ^^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py\",
+        line 1179, in async_completion\n    response = await client.post(\n               ^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/litellm/litellm_core_utils/logging_utils.py\",
+        line 135, in async_wrapper\n    result = await func(*args, **kwargs)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/litellm/llms/custom_httpx/http_handler.py\",
+        line 258, in post\n    raise e\n  File \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/litellm/llms/custom_httpx/http_handler.py\",
+        line 208, in post\n    req = self.client.build_request(\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/httpx/_client.py\",
+        line 346, in build_request\n    url = self._merge_url(url)\n          ^^^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/httpx/_client.py\",
+        line 376, in _merge_url\n    merge_url = URL(url)\n                ^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/httpx/_urls.py\",
+        line 117, in __init__\n    self._uri_reference = urlparse(url, **kwargs)\n                          ^^^^^^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/httpx/_urlparse.py\",
+        line 260, in urlparse\n    parsed_port: int | None = normalize_port(port,
+        scheme)\n                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/httpx/_urlparse.py\",
+        line 366, in normalize_port\n    raise InvalidURL(f\"Invalid port: {port!r}\")\nhttpx.InvalidURL:
+        Invalid port: ''generateContent''\n"}'
+    headers:
+      content-length:
+      - '2485'
+      content-type:
+      - application/json
+    status:
+      code: 500
+      message: Internal Server Error
+- request:
+    body: '{"messages": [{"role": "user", "content": "Hello, how are you?"}], "model":
+      "gemini/gemini-2.0-flash"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      base_url:
+      - http://non.existent.endpoint
+      connection:
+      - keep-alive
+      content-length:
+      - '102'
+      content-type:
+      - application/json
+      host:
+      - localhost:30001
+      user-agent:
+      - AsyncOpenAI/Python 1.76.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.76.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.12
+    method: POST
+    uri: http://localhost:30001/chat/completions
+  response:
+    body:
+      string: '{"detail":"Chat completion failed: litellm.APIConnectionError: Invalid
+        port: ''generateContent''\nTraceback (most recent call last):\n  File \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/httpx/_urlparse.py\",
+        line 364, in normalize_port\n    port_as_int = int(port)\n                  ^^^^^^^^^\nValueError:
+        invalid literal for int() with base 10: ''generateContent''\n\nDuring handling
+        of the above exception, another exception occurred:\n\nTraceback (most recent
+        call last):\n  File \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/litellm/main.py\",
+        line 477, in acompletion\n    response = await init_response\n               ^^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py\",
+        line 1179, in async_completion\n    response = await client.post(\n               ^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/litellm/litellm_core_utils/logging_utils.py\",
+        line 135, in async_wrapper\n    result = await func(*args, **kwargs)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/litellm/llms/custom_httpx/http_handler.py\",
+        line 258, in post\n    raise e\n  File \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/litellm/llms/custom_httpx/http_handler.py\",
+        line 208, in post\n    req = self.client.build_request(\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/httpx/_client.py\",
+        line 346, in build_request\n    url = self._merge_url(url)\n          ^^^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/httpx/_client.py\",
+        line 376, in _merge_url\n    merge_url = URL(url)\n                ^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/httpx/_urls.py\",
+        line 117, in __init__\n    self._uri_reference = urlparse(url, **kwargs)\n                          ^^^^^^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/httpx/_urlparse.py\",
+        line 260, in urlparse\n    parsed_port: int | None = normalize_port(port,
+        scheme)\n                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/httpx/_urlparse.py\",
+        line 366, in normalize_port\n    raise InvalidURL(f\"Invalid port: {port!r}\")\nhttpx.InvalidURL:
+        Invalid port: ''generateContent''\n"}'
+    headers:
+      content-length:
+      - '2485'
+      content-type:
+      - application/json
+    status:
+      code: 500
+      message: Internal Server Error
+- request:
+    body: '{"messages": [{"role": "user", "content": "Hello, how are you?"}], "model":
+      "gemini/gemini-2.0-flash"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      base_url:
+      - http://non.existent.endpoint
+      connection:
+      - keep-alive
+      content-length:
+      - '102'
+      content-type:
+      - application/json
+      host:
+      - localhost:30001
+      user-agent:
+      - AsyncOpenAI/Python 1.76.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.76.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '2'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.12
+    method: POST
+    uri: http://localhost:30001/chat/completions
+  response:
+    body:
+      string: '{"detail":"Chat completion failed: litellm.APIConnectionError: Invalid
+        port: ''generateContent''\nTraceback (most recent call last):\n  File \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/httpx/_urlparse.py\",
+        line 364, in normalize_port\n    port_as_int = int(port)\n                  ^^^^^^^^^\nValueError:
+        invalid literal for int() with base 10: ''generateContent''\n\nDuring handling
+        of the above exception, another exception occurred:\n\nTraceback (most recent
+        call last):\n  File \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/litellm/main.py\",
+        line 477, in acompletion\n    response = await init_response\n               ^^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py\",
+        line 1179, in async_completion\n    response = await client.post(\n               ^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/litellm/litellm_core_utils/logging_utils.py\",
+        line 135, in async_wrapper\n    result = await func(*args, **kwargs)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/litellm/llms/custom_httpx/http_handler.py\",
+        line 258, in post\n    raise e\n  File \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/litellm/llms/custom_httpx/http_handler.py\",
+        line 208, in post\n    req = self.client.build_request(\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/httpx/_client.py\",
+        line 346, in build_request\n    url = self._merge_url(url)\n          ^^^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/httpx/_client.py\",
+        line 376, in _merge_url\n    merge_url = URL(url)\n                ^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/httpx/_urls.py\",
+        line 117, in __init__\n    self._uri_reference = urlparse(url, **kwargs)\n                          ^^^^^^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/httpx/_urlparse.py\",
+        line 260, in urlparse\n    parsed_port: int | None = normalize_port(port,
+        scheme)\n                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File
+        \"/Users/nik/code/Adala/.venv/lib/python3.11/site-packages/httpx/_urlparse.py\",
+        line 366, in normalize_port\n    raise InvalidURL(f\"Invalid port: {port!r}\")\nhttpx.InvalidURL:
+        Invalid port: ''generateContent''\n"}'
+    headers:
+      content-length:
+      - '2485'
+      content-type:
+      - application/json
+    status:
+      code: 500
+      message: Internal Server Error
+version: 1

--- a/tests/cassettes/test_server/test_chat_completion_endpoint_error_handling.yaml
+++ b/tests/cassettes/test_server/test_chat_completion_endpoint_error_handling.yaml
@@ -22,13 +22,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/61R0U6DMBR95ytqnzczmAz0xRg1ccZlixKjUWOucscaSkto2cRl/24B2br5ah+a
-        5p7Te+49Z+0QQj9BxCwGjYqekRdTIWTd3DUmhUahDdCVTDGHQu+47Vlbb0PR+FV/omMCGYklEwlZ
-        Iec9ohcgUlLJksxlQUClBjoiN3JFoMCmrmUM1fmroFbHzfb91tvNUUiOtUgmY+QdfdMR6JwJphb3
-        CEqKmvYQTWd0i8IyuZNJXsiPepX+4HgwDAI3dId+OBr6J57vB04n3YjSUkGCE9RgvIKtI9S0yHId
-        yRTFpSwbr0atiuXsHux2uJYa+B7keb0/XdWV0WTcdtwKwywPnOmq3jC6foqoZZDeG6ozyLF8PBzx
-        n7TcAzHnN5c2qkcsFGszSTAzKfW940F/zkEtmo60QJVLoXAc1xw2Ll2Y4vvt8zcLJuHsdLoMq4uU
-        OhvnBxC84mHAAgAA
+        H4sIAAAAAAAC/61SwW7TQBC9+yuGvXBJIidt2pQLQgWpEaAWSAsScJjGY3uV9Y61uya1ovw7s06d
+        OpzxwVrtezPz5r3dJQBqjTbTGQby6g38lBuAXfePGNtANgjQX8lljS68cA/fbnAWSqCnWKSWgBVk
+        rG0BWzJmBKFEu4GWG8jZAfqNQK/gnQcEg64g+duiQTlUnJEULKXcvg5ATzU5TXZNQBUHzdaDdMiJ
+        jLTwoK30JvBYEWyxhbKpUCgZj+CxCdAJyRu7jpVRDtdBV2hMC7I+OMKshcCiyGsfosAJ3PAWxByp
+        LcnUnejAGbZvf1k1WHd/PP8evZjk2FB0oFujp+97gsq11b78SujZRtq31e2dOqL4p/jERe34Mfo8
+        Tifp+exscbW4SKfzs+nVYnae9JO7marxYtlnCig54jEtJR2qOqx4Q/aamy7Hi8OQQeon8Dx9xgMH
+        NKdQXzro6t/LTG2Gr2HwUGR3NDq0ccHVhx8rNfAnnIjq/UkGNv4r8T/Nmqenw5LnWA5JPZDz+hBJ
+        QZWENJ5N0nFu0JddR+XI1/L2aJlFzvbyeorLm+Zjfnu5ye7vGvq+1l9YJfvkL0NhMvJcAwAA
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -37,11 +38,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 01 Sep 2025 12:03:20 GMT
+      - Mon, 01 Sep 2025 14:42:12 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=423
+      - gfet4t7; dur=807
       Transfer-Encoding:
       - chunked
       Vary:
@@ -74,7 +75,7 @@ interactions:
       host:
       - localhost:30001
       user-agent:
-      - AsyncOpenAI/Python 1.76.0
+      - AsyncOpenAI/Python 1.102.0
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -84,7 +85,7 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 1.76.0
+      - 1.102.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
@@ -97,11 +98,13 @@ interactions:
     uri: http://localhost:30001/chat/completions
   response:
     body:
-      string: '{"id":"chatcmpl-26e1bc3a-2b1a-4917-bb03-49e951b15c35","object":"chat.completion","created":1756728200,"model":"gemini-2.0-flash","choices":[{"finish_reason":"stop","index":0,"message":{"content":"I
-        am doing well, thank you for asking! How are you today?\n","role":"assistant","tool_calls":null,"function_call":null},"logprobs":-0.03771813586354256}],"usage":{"completion_tokens":16,"prompt_tokens":6,"total_tokens":22,"completion_tokens_details":null,"prompt_tokens_details":{"audio_tokens":null,"cached_tokens":null}},"service_tier":"default"}'
+      string: '{"id":"chatcmpl-9f43a26c-1e47-4edc-891a-7b2bf46dca3a","object":"chat.completion","created":1756737731,"model":"gemini-2.0-flash","choices":[{"finish_reason":"stop","index":0,"message":{"content":"I
+        am doing well, thank you for asking! As a large language model, I don''t experience
+        emotions or feelings in the same way humans do, but I am functioning optimally
+        and ready to assist you. How can I help you today?\n","role":"assistant","tool_calls":null,"function_call":null},"logprobs":-0.04238986015319824}],"usage":{"completion_tokens":50,"prompt_tokens":6,"total_tokens":56,"completion_tokens_details":null,"prompt_tokens_details":{"audio_tokens":null,"cached_tokens":null}},"service_tier":"default"}'
     headers:
       content-length:
-      - '544'
+      - '701'
       content-type:
       - application/json
     status:
@@ -126,7 +129,7 @@ interactions:
       host:
       - localhost:30001
       user-agent:
-      - AsyncOpenAI/Python 1.76.0
+      - AsyncOpenAI/Python 1.102.0
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -136,7 +139,7 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 1.76.0
+      - 1.102.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
@@ -202,7 +205,7 @@ interactions:
       host:
       - localhost:30001
       user-agent:
-      - AsyncOpenAI/Python 1.76.0
+      - AsyncOpenAI/Python 1.102.0
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -212,7 +215,7 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 1.76.0
+      - 1.102.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
@@ -278,7 +281,7 @@ interactions:
       host:
       - localhost:30001
       user-agent:
-      - AsyncOpenAI/Python 1.76.0
+      - AsyncOpenAI/Python 1.102.0
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -288,7 +291,7 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 1.76.0
+      - 1.102.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:

--- a/tests/cassettes/test_server/test_chat_completion_endpoint_openai_client.yaml
+++ b/tests/cassettes/test_server/test_chat_completion_endpoint_openai_client.yaml
@@ -22,14 +22,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/61STW/aQBC9+1dM99ILIKCA1V6qKI1UIqqSFLWV2hwmeGyvWO9a3nESC/HfO2ti
-        Yppr9rBazZuPN+/tPgJQW7SJTpDJq0/wRyIA+/YOmLNMlgXoQhIsseKX3OPZ996SwvQUitQSsIDE
-        aZvBIxkzAM7R7qBxNaSuAvQ7gd7BhQcEg1VGctusRnkULiEpWEq5fc9ATyVVmuyWgArH2lkP0iEl
-        MtLCg9E7grwuUOKJG8B9zdBOT2u7DemBgytZF2hMA7IzVIRJA+yEhteeA6sRfHWPIIpIbU6mbJmy
-        S7D5/Neq3o6H0/tu8KJM5QyFtVvuXfqhS1Cpttrnt4Te2ZD2Y/N9rU4oPmQrl5WVuw/iDsej8XwR
-        L6bxR7nj6WQ2n0yibnQ7VNVehPpGjOIenjxS0qIoeeN2ZC9d3bq3OE7peX0Gz+JnnB2jOYPmHwav
-        uvovMlOb/h/ofQ9ZHo3mJmy4ufq9UT2B+IxUJ1DU0/F/im80axafD4uefTla9ZMqr4+eZFSIS8Pp
-        aDxMDfq87agq8qX8OFomISe90A+4Wq+u+dfY+qs1Xzd1c3OjokP0DzJurrBSAwAA
+        H4sIAAAAAAAC/61SwW7TQBC9+yuGvXBJIpOmScsFVRSpQVSNIEIgQGgaj+1V1jvW7prWRPl3Zp06
+        deCKLa1WM2/mvZm3uwRAbdBmOsNAXr2GbxIB2HVnzLENZIMk+pAEa3ThGXv4doO7QAI9xiK1BKwg
+        Y20LeCBjRhBKtFtouYGcHaDfSuoFXHlAMOgKktMWDcql4oykYCnl9mUAeqzJabIbAqo4aLYepENO
+        ZKSFB6O3BGVTocQzHsF9E6Bjzxu7ifCogeugKzSmBZkZHGHWQmCR4bUPUdUEbvgBZCNSW5KpO6WB
+        M2zffLdqMOP+eP8xet6MY0Nx7E57D9/3AJVrq335kdCzjbBP67uVOmbxV/GBi9rxfVzuOJ2ks4X8
+        6dlsenGZXs6n83nSU3ekqvGyqFsKKO7h0SMlLao6rHlL9i03nXvzA8vA65P0bPGUDxzQnKTOz0b/
+        dPXXwqnN8A0MnocMj0aHNk64fvdlrQYLCiei+gUlgz3+LfE/cc0Wp2TJky8Hqz6T8/rgSUGVuDSe
+        TtJxbtCXXUflyNfy4miZdZivzStc0c+b8996cXuxcnfX75srVsk++QNPjAV+UgMAAA==
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -38,11 +38,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 27 Aug 2025 13:30:37 GMT
+      - Mon, 01 Sep 2025 12:03:14 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=704
+      - gfet4t7; dur=812
       Transfer-Encoding:
       - chunked
       Vary:
@@ -98,13 +98,13 @@ interactions:
     uri: http://localhost:30001/chat/completions
   response:
     body:
-      string: '{"id":"chatcmpl-38f02a73-ec84-4e09-b470-a468018a7eee","object":"chat.completion","created":1756301436,"model":"gemini-2.0-flash","choices":[{"finish_reason":"stop","index":0,"message":{"content":"I
+      string: '{"id":"chatcmpl-d6480e6a-098d-4bcf-9eee-c575ff43b37e","object":"chat.completion","created":1756728193,"model":"gemini-2.0-flash","choices":[{"finish_reason":"stop","index":0,"message":{"content":"I
         am doing well, thank you for asking! As a large language model, I don''t experience
         emotions or feelings like humans do, but I am functioning optimally and ready
-        to assist you. How can I help you today?\n","role":"assistant","tool_calls":null,"function_call":null},"logprobs":-0.05676279676721451}],"usage":{"completion_tokens":47,"prompt_tokens":6,"total_tokens":53,"completion_tokens_details":null,"prompt_tokens_details":{"audio_tokens":null,"cached_tokens":null}},"service_tier":"default"}'
+        to assist you. How can I help you today?\n","role":"assistant","tool_calls":null,"function_call":null},"logprobs":-0.047474034289096266}],"usage":{"completion_tokens":47,"prompt_tokens":6,"total_tokens":53,"completion_tokens_details":null,"prompt_tokens_details":{"audio_tokens":null,"cached_tokens":null}},"service_tier":"default"}'
     headers:
       content-length:
-      - '690'
+      - '691'
       content-type:
       - application/json
     status:

--- a/tests/cassettes/test_server/test_chat_completion_endpoint_openai_client.yaml
+++ b/tests/cassettes/test_server/test_chat_completion_endpoint_openai_client.yaml
@@ -22,14 +22,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/61SwW7TQBC9+yuGvXBJIpOmScsFVRSpQVSNIEIgQGgaj+1V1jvW7prWRPl3Zp06
-        deCKLa1WM2/mvZm3uwRAbdBmOsNAXr2GbxIB2HVnzLENZIMk+pAEa3ThGXv4doO7QAI9xiK1BKwg
-        Y20LeCBjRhBKtFtouYGcHaDfSuoFXHlAMOgKktMWDcql4oykYCnl9mUAeqzJabIbAqo4aLYepENO
-        ZKSFB6O3BGVTocQzHsF9E6Bjzxu7ifCogeugKzSmBZkZHGHWQmCR4bUPUdUEbvgBZCNSW5KpO6WB
-        M2zffLdqMOP+eP8xet6MY0Nx7E57D9/3AJVrq335kdCzjbBP67uVOmbxV/GBi9rxfVzuOJ2ks4X8
-        6dlsenGZXs6n83nSU3ekqvGyqFsKKO7h0SMlLao6rHlL9i03nXvzA8vA65P0bPGUDxzQnKTOz0b/
-        dPXXwqnN8A0MnocMj0aHNk64fvdlrQYLCiei+gUlgz3+LfE/cc0Wp2TJky8Hqz6T8/rgSUGVuDSe
-        TtJxbtCXXUflyNfy4miZdZivzStc0c+b8996cXuxcnfX75srVsk++QNPjAV+UgMAAA==
+        H4sIAAAAAAAC/61STW/TQBC9+1cMe+GSREljGsoFQahKJFALRAgJEJrGY3uV9Y67u6a1ovx3Zp06
+        deDKHlareW++3ttdAqA2aDOdYSCvXsF3iQDsujtibAPZIEAfkmCNLjxxD2c3eAsl0ENMUivACjLW
+        toB7MmYEoUS7hZYbyNkB+q1Az+CNBwSDriC5bdGgPCrOSBJWkm6fB6CHmpwmuyGgioNm60Eq5ERG
+        SngwektQNhVKPOMR3DYBuu55YzeRHmfgOugKjWlBdgZHmLUQWMbw2oc41QTe8z2IIpJbkqm7SQNn
+        2L7+YdVgx/3x/XP0pIxjQ3Htbvaevu8JKtdW+/IzoWcbaV/W1zfqiOLv4gMXtePbKO54Opmmi4uL
+        dDY/fzmbzqdni3ma9K27pqrxItRHCiju4dEjJSWqOqx5S3bJTefe+aHLwOsTOF084oEDmhPoxXz0
+        T1X/TnpqM/wDg+8hy6PRoY0bri+/rdVAoHAyVC9QMtDx7xH/U690cdosefTlYNVXcl4fPCmoEpfG
+        Z5PpODfoy66icuRr+XG0yiLHuOUMr6+u3t4tU+svb+pfd03ziVWyT/4A4Brg91IDAAA=
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -38,11 +38,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 01 Sep 2025 12:03:14 GMT
+      - Mon, 01 Sep 2025 14:41:26 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=812
+      - gfet4t7; dur=552
       Transfer-Encoding:
       - chunked
       Vary:
@@ -75,7 +75,7 @@ interactions:
       host:
       - localhost:30001
       user-agent:
-      - AsyncOpenAI/Python 1.76.0
+      - AsyncOpenAI/Python 1.102.0
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -85,7 +85,7 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 1.76.0
+      - 1.102.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
@@ -98,10 +98,10 @@ interactions:
     uri: http://localhost:30001/chat/completions
   response:
     body:
-      string: '{"id":"chatcmpl-d6480e6a-098d-4bcf-9eee-c575ff43b37e","object":"chat.completion","created":1756728193,"model":"gemini-2.0-flash","choices":[{"finish_reason":"stop","index":0,"message":{"content":"I
+      string: '{"id":"chatcmpl-2b0f240b-8fb8-4837-98a5-0fe889f6b656","object":"chat.completion","created":1756737685,"model":"gemini-2.0-flash","choices":[{"finish_reason":"stop","index":0,"message":{"content":"I
         am doing well, thank you for asking! As a large language model, I don''t experience
         emotions or feelings like humans do, but I am functioning optimally and ready
-        to assist you. How can I help you today?\n","role":"assistant","tool_calls":null,"function_call":null},"logprobs":-0.047474034289096266}],"usage":{"completion_tokens":47,"prompt_tokens":6,"total_tokens":53,"completion_tokens_details":null,"prompt_tokens_details":{"audio_tokens":null,"cached_tokens":null}},"service_tier":"default"}'
+        to assist you. How can I help you today?\n","role":"assistant","tool_calls":null,"function_call":null},"logprobs":-0.047994136810302734}],"usage":{"completion_tokens":47,"prompt_tokens":6,"total_tokens":53,"completion_tokens_details":null,"prompt_tokens_details":{"audio_tokens":null,"cached_tokens":null}},"service_tier":"default"}'
     headers:
       content-length:
       - '691'

--- a/tests/cassettes/test_server/test_custom_provider_with_anthropic_endpoint.yaml
+++ b/tests/cassettes/test_server/test_custom_provider_with_anthropic_endpoint.yaml
@@ -1,0 +1,507 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": "Hello, how are you?"}], "model":
+      "claude-opus-4-1-20250805"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '103'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncOpenAI/Python 1.102.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.102.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.12
+    method: POST
+    uri: https://api.anthropic.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0SQQW/bMAyF/wrHSy9KYCd1Uugy7NRswHrZoYdhCFiLtdTIoifR8YIg/32wh7XX
+        D+R7H94Vg0OLfemOVb09fPvx9Pj0QJtn9/3LfuTd88u2RoOtl9ByQfvziq8hheKPmalIQotFZUCD
+        ITn+g7Yy2HMp1DHaK2aJjBaplFCUks5RkpSTosUDxyif4OtdD05C6mDiGA2op3SCi4zwKhmonELq
+        1suV58xAyUFmchdQAc9xgCmoh8mT8pnz8tiHziskZgcrmDyr5zzn6l0BSmXiPNf9HrlokFQMeDrP
+        hKCVdOZcaOYGlv5ZfbGbawiUymkNB5mAMi9t/+RVHF0+4+32y2CbmZQd2nrf7Pb31bbaGezFcUSL
+        baTR8UqGsazuV/VqU22a6qFq0KC8vHE7T9N60nUr/RB5NkGD4/9JP+hR5cSpoG02Bocs/aDvqN4a
+        VFGK72TX3G5/AQAA//8DADt7P2btAQAA
+    headers:
+      CF-RAY:
+      - 9785c72f0cb603be-LIS
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Sep 2025 15:25:06 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+      x-envoy-upstream-service-time:
+      - '3012'
+      x-request-id:
+      - req_011CShuupVRTYgMrYsxsQxFo
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"role": "user", "content": "Hello, how are you?"}], "model":
+      "claude-opus-4-1-20250805"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '103'
+      content-type:
+      - application/json
+      host:
+      - localhost:30001
+      user-agent:
+      - AsyncOpenAI/Python 1.102.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.102.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.12
+    method: POST
+    uri: http://localhost:30001/chat/completions
+  response:
+    body:
+      string: '{"id":"msg_013HJSNGN8a2WdMA7ue6Wb31","object":"chat.completion","created":1756740306,"model":"claude-opus-4-1-20250805","choices":[{"finish_reason":"stop","index":0,"logprobs":null,"message":{"content":"Hello!
+        I''m doing well, thank you for asking. I''m here and ready to help with whatever
+        you might need - whether that''s answering questions, having a conversation,
+        or assisting with a task. How are you doing today?","refusal":null,"role":"assistant","annotations":null,"audio":null,"function_call":null,"tool_calls":null}}],"usage":{"completion_tokens":52,"prompt_tokens":13,"total_tokens":65,"completion_tokens_details":null,"prompt_tokens_details":null},"service_tier":null}'
+    headers:
+      content-length:
+      - '677'
+      content-type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"role": "user", "content": "Hello, how are you?"}], "model":
+      "invalid-model-name"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '97'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncOpenAI/Python 1.102.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.102.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.12
+    method: POST
+    uri: https://api.anthropic.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzzMWwqAMAxE0a3IfOsGupkSbBShTWraCiLuXXzg53CGe4DN1OAOjBoYDqLVT9ok
+        +Fd6JC6F5tuSBo6uW2SjuIThmYNQYvSoe74vn3njtXGpfySTUYKTFuN5XgAAAP//AwDkVcdDdgAA
+        AA==
+    headers:
+      CF-RAY:
+      - 9785c7430c08e3b0-LIS
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Sep 2025 15:25:06 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+      x-envoy-upstream-service-time:
+      - '19'
+      x-request-id:
+      - req_011CShuv49xCbu6WSTxsJbVp
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: '{"messages": [{"role": "user", "content": "Hello, how are you?"}], "model":
+      "invalid-model-name"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '97'
+      content-type:
+      - application/json
+      host:
+      - localhost:30001
+      user-agent:
+      - AsyncOpenAI/Python 1.102.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.102.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.12
+    method: POST
+    uri: http://localhost:30001/chat/completions
+  response:
+    body:
+      string: '{"detail":"Chat completion failed: Error code: 404 - {''error'': {''code'':
+        ''not_found_error'', ''message'': ''model: invalid-model-name'', ''type'':
+        ''invalid_request_error'', ''param'': None}}"}'
+    headers:
+      content-length:
+      - '181'
+      content-type:
+      - application/json
+    status:
+      code: 500
+      message: Internal Server Error
+- request:
+    body: '{"messages": [{"role": "user", "content": "Hello, how are you?"}], "model":
+      "invalid-model-name"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '97'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncOpenAI/Python 1.102.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.102.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.12
+    method: POST
+    uri: https://api.anthropic.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzzMWwqAMAxE0a3IfOsGupkSbBShTWraCiLuXXzg53CGe4DN1OAOjBoYDqLVT9ok
+        +Fd6JC6F5tuSBo6uW2SjuIThmYNQYvSoe74vn3njtXGpfySTUYKTFuN5XgAAAP//AwDkVcdDdgAA
+        AA==
+    headers:
+      CF-RAY:
+      - 9785c7476e47338d-LIS
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Sep 2025 15:25:07 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+      x-envoy-upstream-service-time:
+      - '108'
+      x-request-id:
+      - req_011CShuv7BmGfS7pSKZmsdrx
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: '{"messages": [{"role": "user", "content": "Hello, how are you?"}], "model":
+      "invalid-model-name"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '97'
+      content-type:
+      - application/json
+      host:
+      - localhost:30001
+      user-agent:
+      - AsyncOpenAI/Python 1.102.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.102.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.12
+    method: POST
+    uri: http://localhost:30001/chat/completions
+  response:
+    body:
+      string: '{"detail":"Chat completion failed: Error code: 404 - {''error'': {''code'':
+        ''not_found_error'', ''message'': ''model: invalid-model-name'', ''type'':
+        ''invalid_request_error'', ''param'': None}}"}'
+    headers:
+      content-length:
+      - '181'
+      content-type:
+      - application/json
+    status:
+      code: 500
+      message: Internal Server Error
+- request:
+    body: '{"messages": [{"role": "user", "content": "Hello, how are you?"}], "model":
+      "invalid-model-name"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '97'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncOpenAI/Python 1.102.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.102.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.12
+    method: POST
+    uri: https://api.anthropic.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//PMxbCoAwDETRrch86wa6mRJsFKFNatoKIu5dfODncIZ7gM3U4A6MGhgO
+        otVP2iT4V3okLoXm25IGjq5bZKO4hOGZg1Bi9Kh7vi+feeO1cal/JJNRgpMW43leAAAA//8DAORV
+        x0N2AAAA
+    headers:
+      CF-RAY:
+      - 9785c74f4b0d7113-LIS
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 01 Sep 2025 15:25:08 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+      x-envoy-upstream-service-time:
+      - '19'
+      x-request-id:
+      - req_011CShuvCXEkagsDVdcspE2T
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: '{"messages": [{"role": "user", "content": "Hello, how are you?"}], "model":
+      "invalid-model-name"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '97'
+      content-type:
+      - application/json
+      host:
+      - localhost:30001
+      user-agent:
+      - AsyncOpenAI/Python 1.102.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.102.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '2'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.12
+    method: POST
+    uri: http://localhost:30001/chat/completions
+  response:
+    body:
+      string: '{"detail":"Chat completion failed: Error code: 404 - {''error'': {''code'':
+        ''not_found_error'', ''message'': ''model: invalid-model-name'', ''type'':
+        ''invalid_request_error'', ''param'': None}}"}'
+    headers:
+      content-length:
+      - '181'
+      content-type:
+      - application/json
+    status:
+      code: 500
+      message: Internal Server Error
+version: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,6 @@ def vcr_config():
     return {
         "filter_headers": ["authorization", "api-key", "x-api-key"],
         "filter_query_parameters": ["api_key", "key"],
-        "filter_post_data_parameters": ["api_key"],
         "match_on": ("method", "scheme", "host", "port", "path", "query", "body"),
     }
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -601,14 +601,18 @@ def test_chat_completion_endpoint_api_client(client):
     """Test the chat/completion endpoint using sync requests with OpenAI format validation."""
 
     # Make a direct request using the existing test client fixture
-    encoded_credentials = base64.b64encode(json.dumps({
-        'api_key': os.getenv("GEMINI_API_KEY"),
-        'iat': time.time(),
-        'iss': 'test',
-        'exp': time.time() + 3600,
-        'sub': 'test',
-        'additional': 'payload',
-    }).encode('utf-8')).decode('utf-8')
+    encoded_credentials = base64.b64encode(
+        json.dumps(
+            {
+                "api_key": os.getenv("GEMINI_API_KEY"),
+                "iat": time.time(),
+                "iss": "test",
+                "exp": time.time() + 3600,
+                "sub": "test",
+                "additional": "payload",
+            }
+        ).encode("utf-8")
+    ).decode("utf-8")
     response = client.post(
         "/chat/completions",
         headers={
@@ -718,19 +722,21 @@ async def test_chat_completion_endpoint_error_handling():
 
     # note that here we use a different schema to pass the `api_key`.
     # the reason is because different providers may require additional credentials.
-    encoded_credentials = base64.b64encode(json.dumps({'api_key': os.getenv("GEMINI_API_KEY")}).encode('utf-8')).decode('utf-8')
+    encoded_credentials = base64.b64encode(
+        json.dumps({"api_key": os.getenv("GEMINI_API_KEY")}).encode("utf-8")
+    ).decode("utf-8")
     client = AsyncOpenAI(
         base_url="http://localhost:30001",
         api_key=encoded_credentials,
         http_client=http_client,
     )
-    
+
     # First test with valid configuration to ensure it passes
     response = await client.chat.completions.create(
         model="gemini/gemini-2.0-flash",
         messages=[{"role": "user", "content": "Hello, how are you?"}],
     )
-    
+
     # Verify the response structure matches OpenAI's format
     assert hasattr(response, "choices")
     assert hasattr(response, "model")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -755,3 +755,56 @@ async def test_chat_completion_endpoint_error_handling():
 
     # Clean up
     await http_client.aclose()
+
+
+@pytest.mark.vcr
+@pytest.mark.asyncio
+async def test_custom_provider_with_anthropic_endpoint():
+    """Test using OpenAI client with `Custom` provider configuration pointing to Anthropic API."""
+    from server.app import app
+
+    # Create async httpx client with ASGITransport for mocked test server
+    http_client = httpx.AsyncClient(transport=httpx.ASGITransport(app=app))
+
+    # Configure credentials for custom provider pointing to Anthropic
+    encoded_credentials = base64.b64encode(
+        json.dumps(
+            {
+                "api_key": os.getenv("ANTHROPIC_API_KEY", "test-key"),
+                "provider": "Custom",
+                "base_url": "https://api.anthropic.com/v1/",
+            }
+        ).encode("utf-8")
+    ).decode("utf-8")
+
+    client = AsyncOpenAI(
+        base_url="http://localhost:30001",
+        api_key=encoded_credentials,
+        http_client=http_client,
+    )
+
+    response = await client.chat.completions.create(
+        model="claude-opus-4-1-20250805",
+        messages=[{"role": "user", "content": "Hello, how are you?"}],
+    )
+
+    # Verify the response structure matches OpenAI's format
+    assert hasattr(response, "choices")
+    assert hasattr(response, "model")
+    assert hasattr(response, "usage")
+    assert len(response.choices) > 0
+    assert "thank you" in response.choices[0].message.content.lower()
+
+    # Test should handle the invalid model name
+    with pytest.raises(Exception) as exc_info:
+        response = await client.chat.completions.create(
+            model="invalid-model-name",
+            messages=[{"role": "user", "content": "Hello, how are you?"}],
+        )
+
+    # Verify that the exception is related to API format or authentication issues
+    # rather than configuration problems
+    assert exc_info.value is not None
+
+    # Clean up
+    await http_client.aclose()


### PR DESCRIPTION
**Before:**
Only a single `api_key` string can be passed in `/chat/completions` endpoint via headers or JSON body

**After:**
- Complex JSON payloads (e.g., where more than one credential string is required, like with VertexAI connections) are supported.
- The JSON body parameter has been removed to tighten security controls.