### PR TITLE
docs: add OrcaRouter as an OpenAI-compatible provider example

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,90 @@ print('\n => Test results:')
 print(predictions)
 ```
 
+You can also route Adala through [OrcaRouter](https://www.orcarouter.ai) — an OpenAI-compatible gateway that exposes a provider/model namespace across many models behind a single endpoint, with adaptive routing and automatic failover. Below is an example of how to use the OrcaRouter API:
+
+Start by setting the `ORCAROUTER_API_KEY` environment variable, which you can get from the [OrcaRouter dashboard](https://www.orcarouter.ai).
+
+```
+export ORCAROUTER_API_KEY='your-orcarouter-api-key'
+```
+
+Then, let's see how to modify the previous example to use OrcaRouter with the `orcarouter/auto` model, which routes each request to a live model:
+
+```python
+import os
+import pandas as pd
+
+from adala.agents import Agent
+from adala.environments import StaticEnvironment
+from adala.skills import ClassificationSkill
+from adala.runtimes import OpenAIChatRuntime
+from rich import print
+
+# Train dataset
+train_df = pd.DataFrame([
+    ["It was the negative first impressions, and then it started working.", "Positive"],
+    ["Not loud enough and doesn't turn on like it should.", "Negative"],
+    ["I don't know what to say.", "Neutral"],
+    ["Manager was rude, but the most important that mic shows very flat frequency response.", "Positive"],
+    ["The phone doesn't seem to accept anything except CBR mp3s.", "Negative"],
+    ["I tried it before, I bought this device for my son.", "Neutral"],
+], columns=["text", "sentiment"])
+
+# Test dataset
+test_df = pd.DataFrame([
+    "All three broke within two months of use.",
+    "The device worked for a long time, can't say anything bad.",
+    "Just a random line of text."
+], columns=["text"])
+
+agent = Agent(
+    # connect to a dataset
+    environment=StaticEnvironment(df=train_df),
+
+    # define a skill
+    skills=ClassificationSkill(
+        name='sentiment',
+        instructions="Label text as positive, negative or neutral.",
+        labels=["Positive", "Negative", "Neutral"],
+        input_template="Text: {text}",
+        output_template="Sentiment: {sentiment}"
+    ),
+
+    # define all the different runtimes your skills may use
+    runtimes = {
+        # You can specify your OrcaRouter API Key here or set it ahead of time in your environment variable, ORCAROUTER_API_KEY
+        'orcarouter': OpenAIChatRuntime(
+            base_url="https://api.orcarouter.ai/v1",
+            model="orcarouter/auto",
+            api_key=os.getenv("ORCAROUTER_API_KEY"),
+            provider="Custom"
+            ),
+    },
+
+    default_runtime='orcarouter',
+
+    teacher_runtimes = {
+        "default" : OpenAIChatRuntime(
+            base_url="https://api.orcarouter.ai/v1",
+            model="orcarouter/auto",
+            api_key=os.getenv("ORCAROUTER_API_KEY"),
+            provider="Custom"
+        ),
+    }
+)
+
+print(agent)
+print(agent.skills)
+
+agent.learn(learning_iterations=3, accuracy_threshold=0.95)
+
+print('\n=> Run tests ...')
+predictions = agent.run(test_df)
+print('\n => Test results:')
+print(predictions)
+```
+
 ### 👉 Examples
 
 | Skill                                                                              | Description                                                                       | Colab                                                                                                                                                                                                                                        |


### PR DESCRIPTION
## Summary

Adala is an **A**utonomous **DA**ta (**L**)abeling **A**gent framework — agents that acquire data-processing skills through iterative learning against a ground-truth environment, running on top of a litellm-backed `OpenAIChatRuntime`. Adala already documents how to use OpenAI-compatible gateways through `OpenAIChatRuntime(provider="Custom", base_url=...)`, with OpenRouter shown as the current example. This PR adds [OrcaRouter](https://www.orcarouter.ai) as a documented first-class provider, mirroring the existing OpenRouter example so users can point their skills at the OrcaRouter gateway without treating it as an anonymous custom base URL.

## Changes

- Add an "OrcaRouter" example to the README Quickstart, directly after the existing OpenRouter section.
- Uses the same runtime wiring Adala already documents for OpenAI-compatible gateways: `OpenAIChatRuntime(base_url="https://api.orcarouter.ai/v1", model="orcarouter/auto", api_key=os.getenv("ORCAROUTER_API_KEY"), provider="Custom")`.
- Documents the `ORCAROUTER_API_KEY` environment variable and the `orcarouter/auto` model, which routes each request to a live model.

## Verification

- The new example is a full copy of the OpenRouter quickstart block, adjusted only for OrcaRouter's base URL, model, and env var, and it compiles cleanly.
- README fence balance validated (36 fences, balanced).
- **Live test (L3):** with `ORCAROUTER_API_KEY` from the environment, a real chat completion through the documented path (`OpenAI(api_key=..., base_url="https://api.orcarouter.ai/v1")`, model `orcarouter/auto`) returned **HTTP 200** (routed to a live model, reply "ok"). The key was never printed or committed.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team. Questions or a different shape you'd prefer are welcome — Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
